### PR TITLE
Force remove microsoft edge regardless of region/country.

### DIFF
--- a/Get.ps1
+++ b/Get.ps1
@@ -45,6 +45,7 @@ Write-Output "> Downloading Win11Debloat..."
 
 # Download latest version of Win11Debloat from github as zip archive
 Invoke-WebRequest http://github.com/raphire/win11debloat/archive/master.zip -OutFile "$env:TEMP/win11debloat-temp.zip"
+
 # Remove old script folder if it exists
 if(Test-Path "$env:TEMP/Win11Debloat") {
     Write-Output ""

--- a/Get.ps1
+++ b/Get.ps1
@@ -60,20 +60,20 @@ if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and ((winget -v) 
 	}
 
     # Navigate to user temp directory
-    cd $env:TEMP 
+    Set-Location $env:TEMP 
 
     # Download Win11Debloat from github
     Write-Output "> Downloading Win11Debloat..."
     git clone https://github.com/Raphire/Win11Debloat/ 
 
     # Make list of arguments
-    $args = $($PSBoundParameters.GetEnumerator() | ForEach-Object {"-$($_.Key)"})
+    $arguments = $($PSBoundParameters.GetEnumerator() | ForEach-Object {"-$($_.Key)"})
 
     Write-Output ""
 
     # Start & run script with the provided arguments
     Write-Output "> Running Win11Debloat..."
-    $debloatProcess = Start-Process powershell.exe -PassThru -ArgumentList "-executionpolicy bypass -File .\Win11Debloat\Win11Debloat.ps1 $args"
+    $debloatProcess = Start-Process powershell.exe -PassThru -ArgumentList "-executionpolicy bypass -File .\Win11Debloat\Win11Debloat.ps1 $arguments"
     $debloatProcess.WaitForExit()
 
     Write-Output ""

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1126,9 +1126,9 @@ else {
             Write-Output "Attempted to remove microsoft edge from services"
 
             #remove leftover tasks
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateBrowserReplacementTask -Confirm:$false
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineCore -Confirm:$false
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineUA -Confirm:$false
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateBrowserReplacementTask -Confirm:$false -ErrorAction SilentlyContinue
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineCore -Confirm:$false -ErrorAction SilentlyContinue
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineUA -Confirm:$false -ErrorAction SilentlyContinue
 
             Write-Output "Attempted to remove microsoft edge from task scheduler"
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -992,11 +992,6 @@ if ((-not $global:Params.Count) -or $RunDefaults -or $RunWin11Defaults -or ($SPP
 
             PrintHeader 'Custom Mode'
         }
-
-        # this was done for testing if it works correctly - loadstring1
-        # '5' {
-        #     AddParameter 'EdgeRemove' 'Force remove edge regardless of region settings'
-        # }
     }
 }
 else {
@@ -1020,7 +1015,6 @@ else {
         }
         "EdgeRemove" {
             Write-Output "Edge uninstaller v1.1 - made by loadstring1"
-
             
             #give it a chance to uninstall itself before doing it forcefully
 
@@ -1162,7 +1156,6 @@ else {
                     Write-Output "$path doesn't exist. No action was taken."
                 }
             }
-
 
             Write-Output "Microsoft edge should be removed from your system."
             Write-Output "Please keep in mind microsoft edge webview has not been uninstalled. You can uninstall that in settings or control panel."

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1019,68 +1019,137 @@ else {
             continue
         }
         "EdgeRemove" {
-            Write-Output "Attempting to kill all microsoft edge processes."
+            Write-Output "Edge uninstaller v1.1 - made by loadstring1"
+
+            #give it a chance to uninstall itself before doing it forcefully
+
+            if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and ((winget -v) -replace 'v','' -gt 1.4)) {
+                $edgeNamesGet=@("Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe","Microsoft.MicrosoftEdge_8wekyb3d8bbwe","Microsoft.Edge","Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe","Microsoft Edge Update")
+
+                foreach ($edge in $edgeNamesGet) {
+                    try {
+                        winget uninstall $edge
+                        Write-Output "uninstalled edge with winget ($edge)"
+                    }catch{
+                        Write-Output "failed to uninstall edge with winget ($edge)"
+                    }
+                }
+
+                Write-Output "Attempted to uninstall microsoft edge with winget"
+            }else{
+                Write-Output "Looks like you don't have winget installed or your winget version is outdated. Attempting to remove microsoft edge without winget forcefully."
+            }
+
             Stop-Process -Name "*edge*"
+            Write-Output "Attempted to kill all microsoft edge processes"
 
             # I don't know how these hashes work. I assume those update once microsoft edge updates that will be tons of pain keeping this edge remove function up to date - loadstring1
+
+            # my god microsoft edge leaves so much mess in the registry... - loadstring1
+
+            # remove ms edge from autostart
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
-            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "Microsoft Edge Update" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "Microsoft Edge Update" /f
+
+            #remove ms edge from control panel and settings
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f
+            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f
+
+            # remove ms edge leftovers in registry
+            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Clients\StartMenuInternet\Microsoft Edge" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Internet Explorer\Low Rights\ElevationPolicy\{c9abcf16-8dc2-4a95-bae3-24fd98f2ed29}" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdge_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\WOW6432Node\CLSID\{FEAC932B-D6B2-40BF-B7C5-F35FAB41FCCA}\InprocHandler32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Edge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\EdgeUpdate" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\EdgeUpdateDev" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppHost\IndexedDB\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppHost\IndexedDB\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "AppX7rm9drdg8sk7vqndwj3sdjw11x96jc0y_microsoft-edge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "AppX3xxs313wwkfjhythsb8q46xdsq8d2cvv_microsoft-edge-holographic" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeMHT_.mht" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeMHT_.mhtml" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.svg" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.webp" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xht" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xhtml" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xml" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_ftp" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_http" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_https" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.htm" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.html" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_read" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_microsoft-edge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_microsoft-edge-holographic" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_ms-xbl-3d8b930f" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgePDF_.pdf" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_mailto" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f 
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications\Microsoft.MicrosoftEdge_8wekyb3d8bbwe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location\NonPackaged\C:#Program Files (x86)#Microsoft#Edge#Application#msedge.exe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppLaunch" /v "MSEdge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched" /v "{7C5A40EF-A0FB-4BFC-874A-C0F2E0B9FA8E}\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched" /v "MSEdge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Feeds" /v "EdgeMUID" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe!App" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!PdfReader" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\RunNotification" /v "StartupTNotiMicrosoft Edge Update" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Search\JumplistData" /v "MSEdge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\HostActivityManager\CommitHistory\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App" /f
+            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\HostActivityManager\CommitHistory\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" /f
+            reg delete "HKEY_CURRENT_USER\Software\Wow6432Node\Microsoft\EdgeUpdateDev" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{1108FD1C-492F-4251-B9DB-77F0274267B2}\InProcServer32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{209222BB-556D-4EAF-9C53-4ACB9E51731C}\InprocHandler32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{5EA43877-C6D8-4885-B77A-C0BB27E94372}\InprocServer32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{6DD6748E-7DAE-47EF-B4D5-03AA1B06D697}\InProcServer32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{81093D63-7825-417B-BFC8-ADC63FA4E53D}\InprocServer32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{A8E2FC12-D508-44CC-AC5E-883746A1CA4C}\InprocHandler32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{B29F5F83-90DF-479A-BDE7-8A9F4412E394}\InProcServer32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{FEAC932B-D6B2-40BF-B7C5-F35FAB41FCCA}\InprocHandler32" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe%5Cresources.pri" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdge_8wekyb3d8bbwe%5Cresources.pri" /f
+            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge.stable_8wekyb3d8bbwe" /f
+
+            #and there is way more than this i could do this all day but i think its enough i don't want to make this simple script 1k lines of code
+
 
             Write-Output "Attempted to remove microsoft edge from registry"
 
             $ProgramFiles86=${env:ProgramFiles(x86)}
-            
-            #remove microsoft edge executables
-            
-            if (Test-Path -Path $ProgramFiles86"\Microsoft\Edge") {
-                Remove-Item -Force -Recurse $ProgramFiles86"\Microsoft\Edge"
-                Write-Output "Microsoft edge removed from Program Files x86"
+
+            $edgePaths=@(
+                "$ProgramFiles86\Microsoft\Edge",
+                "$ProgramFiles86\Microsoft\EdgeCore",
+                "$ProgramFiles86\Microsoft\EdgeUpdate",
+                "$ProgramFiles86\Microsoft\Temp",
+                "$env:LOCALAPPDATA\Microsoft\Edge"
+                "$env:LOCALAPPDATA\Microsoft\EdgeCore",
+                "$env:LOCALAPPDATA\Microsoft\EdgeUpdate",
+                "$env:ProgramData\Microsoft\EdgeUpdate",
+                "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk",
+                "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk",
+                "$env:PUBLIC\Desktop\Microsoft Edge.lnk"
+            )
+            foreach ($path in $edgePaths){
+                if (Test-Path -Path $path) {
+                    Remove-Item -Force -Recurse $path
+                    Write-Output "Removed $path"
+                }else{
+                    Write-Output "$path doesn't exist. No action was taken."
+                }
             }
 
-            if (Test-Path -Path $ProgramFiles86"\Microsoft\EdgeCore") {
-                Remove-Item -Force -Recurse $ProgramFiles86"\Microsoft\EdgeCore"
-                Write-Output "Microsoft edge core removed from Program Files x86"
-            }
-
-            if (Test-Path -Path $ProgramFiles86"\Microsoft\Temp") {
-                Remove-Item -Force -Recurse $ProgramFiles86"\Microsoft\Temp"
-                Write-Output "Microsoft edge temp folder removed from Program Files x86"
-            }
-
-            #remove microsoft edge userdata
-
-            if (Test-Path -Path $env:LOCALAPPDATA"\Microsoft\Edge") {
-                Remove-Item -Force -Recurse $env:LOCALAPPDATA"\Microsoft\Edge"
-                Write-Output "Microsoft edge user data removed from LocalAppdata"
-            }
-
-            if (Test-Path -Path $env:LOCALAPPDATA"\Microsoft\EdgeCore") {
-                Remove-Item -Force -Recurse $env:LOCALAPPDATA"\Microsoft\EdgeCore"
-                Write-Output "Microsoft edge core removed from LocalAppdata"
-            }
-
-            #remove microsoft edge shortcuts
-
-            if (Test-Path -Path $env:ProgramData"\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk") {
-                Remove-item -Force -Recurse $env:ProgramData"\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk"
-                Write-Output "Microsoft edge has been removed from start menu"
-            }
-
-            if (Test-Path -Path $env:APPDATA"\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk") {
-                Remove-Item -Force -Recurse $env:APPDATA"\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk"
-                Write-Output "Microsoft edge has been removed from quick launch"
-            }
-
-            if (Test-Path -Path "C:\Users\Public\Desktop\Microsoft Edge.lnk") {
-                Remove-Item -Force -Recurse "C:\Users\Public\Desktop\Microsoft Edge.lnk"
-                Write-Output "Microsoft edge has been removed from desktop"
-            }
 
             Write-Output "Microsoft edge should be removed from your system."
-            Write-Output "Please keep in mind microsoft edge webview and microsoft edge update has not been uninstalled. You can uninstall those in settings/control panel."
+            Write-Output "Please keep in mind microsoft edge webview has not been uninstalled. You can uninstall that in settings or control panel."
 
             continue
         }

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1021,11 +1021,12 @@ else {
         "EdgeRemove" {
             Write-Output "Edge uninstaller v1.1 - made by loadstring1"
 
-            #give it a chance to uninstall itself before doing it forcefully
 
+            #give it a chance to uninstall itself before doing it forcefully
+            
             if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and ((winget -v) -replace 'v','' -gt 1.4)) {
                 $edgeNamesGet=@("Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe","Microsoft.MicrosoftEdge_8wekyb3d8bbwe","Microsoft.Edge","Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe","Microsoft Edge Update")
-
+            
                 foreach ($edge in $edgeNamesGet) {
                     try {
                         winget uninstall $edge
@@ -1034,29 +1035,29 @@ else {
                         Write-Output "failed to uninstall edge with winget ($edge)"
                     }
                 }
-
+            
                 Write-Output "Attempted to uninstall microsoft edge with winget"
             }else{
                 Write-Output "Looks like you don't have winget installed or your winget version is outdated. Attempting to remove microsoft edge without winget forcefully."
             }
-
+            
             Stop-Process -Name "*edge*"
             Write-Output "Attempted to kill all microsoft edge processes"
-
+            
             # I don't know how these hashes work. I assume those update once microsoft edge updates that will be tons of pain keeping this edge remove function up to date - loadstring1
-
+            
             # my god microsoft edge leaves so much mess in the registry... - loadstring1
-
+            
             # remove ms edge from autostart
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "Microsoft Edge Update" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "Microsoft Edge Update" /f
-
+            
             #remove ms edge from control panel and settings
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f
-
+            
             # remove ms edge leftovers in registry
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Clients\StartMenuInternet\Microsoft Edge" /f
@@ -1117,14 +1118,30 @@ else {
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe%5Cresources.pri" /f
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdge_8wekyb3d8bbwe%5Cresources.pri" /f
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge.stable_8wekyb3d8bbwe" /f
-
+            
             #and there is way more than this i could do this all day but i think its enough i don't want to make this simple script 1k lines of code
-
-
+            
+            
             Write-Output "Attempted to remove microsoft edge from registry"
-
+            
+            #remove leftover services
+            sc.exe delete "edgeupdate"
+            sc.exe delete "edgeupdatem"
+            sc.exe delete "MicrosoftEdgeElevationService"
+            
+            Write-Output "Attempted to remove microsoft edge from services"
+            
+            #remove leftover tasks
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateBrowserReplacementTask -Confirm:$false
+            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskMachineCore{BEB567CF-A378-44A2-9578-89A3E235F394}" -Confirm:$false
+            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskMachineUA{6D47D77D-DBC2-48D8-9FFC-1346D07E2E8F}" -Confirm:$false
+            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskUserS-1-5-21-2471683600-1030039023-3519664427-1001Core{8205FAB3-AD34-4E03-A2E1-5092347ADEDA}" -Confirm:$false
+            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskUserS-1-5-21-2471683600-1030039023-3519664427-1001UA{ECB907F8-E033-4A73-A66C-8DC70865C0F5}" -Confirm:$false
+            
+            Write-Output "Attempted to remove microsoft edge from task scheduler"
+            
             $ProgramFiles86=${env:ProgramFiles(x86)}
-
+            
             $edgePaths=@(
                 "$ProgramFiles86\Microsoft\Edge",
                 "$ProgramFiles86\Microsoft\EdgeCore",
@@ -1146,8 +1163,8 @@ else {
                     Write-Output "$path doesn't exist. No action was taken."
                 }
             }
-
-
+            
+            
             Write-Output "Microsoft edge should be removed from your system."
             Write-Output "Please keep in mind microsoft edge webview has not been uninstalled. You can uninstall that in settings or control panel."
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1021,12 +1021,12 @@ else {
         "EdgeRemove" {
             Write-Output "Edge uninstaller v1.1 - made by loadstring1"
 
-
-            #give it a chance to uninstall itself before doing it forcefully
             
+            #give it a chance to uninstall itself before doing it forcefully
+
             if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and ((winget -v) -replace 'v','' -gt 1.4)) {
                 $edgeNamesGet=@("Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe","Microsoft.MicrosoftEdge_8wekyb3d8bbwe","Microsoft.Edge","Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe","Microsoft Edge Update")
-            
+
                 foreach ($edge in $edgeNamesGet) {
                     try {
                         winget uninstall $edge
@@ -1035,29 +1035,29 @@ else {
                         Write-Output "failed to uninstall edge with winget ($edge)"
                     }
                 }
-            
+
                 Write-Output "Attempted to uninstall microsoft edge with winget"
             }else{
                 Write-Output "Looks like you don't have winget installed or your winget version is outdated. Attempting to remove microsoft edge without winget forcefully."
             }
-            
-            Stop-Process -Name "*edge*"
+
+            Stop-Process -Name "*edge*" -Force
             Write-Output "Attempted to kill all microsoft edge processes"
-            
+
             # I don't know how these hashes work. I assume those update once microsoft edge updates that will be tons of pain keeping this edge remove function up to date - loadstring1
-            
+
             # my god microsoft edge leaves so much mess in the registry... - loadstring1
-            
+
             # remove ms edge from autostart
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "Microsoft Edge Update" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\StartupApproved\Run" /v "Microsoft Edge Update" /f
-            
+
             #remove ms edge from control panel and settings
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f
-            
+
             # remove ms edge leftovers in registry
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Clients\StartMenuInternet\Microsoft Edge" /f
@@ -1118,30 +1118,28 @@ else {
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe%5Cresources.pri" /f
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdge_8wekyb3d8bbwe%5Cresources.pri" /f
             reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge.stable_8wekyb3d8bbwe" /f
-            
+
             #and there is way more than this i could do this all day but i think its enough i don't want to make this simple script 1k lines of code
-            
-            
+
+
             Write-Output "Attempted to remove microsoft edge from registry"
-            
+
             #remove leftover services
             sc.exe delete "edgeupdate"
             sc.exe delete "edgeupdatem"
             sc.exe delete "MicrosoftEdgeElevationService"
-            
+
             Write-Output "Attempted to remove microsoft edge from services"
-            
+
             #remove leftover tasks
             Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateBrowserReplacementTask -Confirm:$false
-            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskMachineCore{BEB567CF-A378-44A2-9578-89A3E235F394}" -Confirm:$false
-            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskMachineUA{6D47D77D-DBC2-48D8-9FFC-1346D07E2E8F}" -Confirm:$false
-            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskUserS-1-5-21-2471683600-1030039023-3519664427-1001Core{8205FAB3-AD34-4E03-A2E1-5092347ADEDA}" -Confirm:$false
-            Unregister-ScheduledTask -TaskName "MicrosoftEdgeUpdateTaskUserS-1-5-21-2471683600-1030039023-3519664427-1001UA{ECB907F8-E033-4A73-A66C-8DC70865C0F5}" -Confirm:$false
-            
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineCore -Confirm:$false
+            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineUA -Confirm:$false
+
             Write-Output "Attempted to remove microsoft edge from task scheduler"
-            
+
             $ProgramFiles86=${env:ProgramFiles(x86)}
-            
+
             $edgePaths=@(
                 "$ProgramFiles86\Microsoft\Edge",
                 "$ProgramFiles86\Microsoft\EdgeCore",
@@ -1153,6 +1151,7 @@ else {
                 "$env:ProgramData\Microsoft\EdgeUpdate",
                 "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk",
                 "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk",
+                "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk"
                 "$env:PUBLIC\Desktop\Microsoft Edge.lnk"
             )
             foreach ($path in $edgePaths){
@@ -1163,11 +1162,10 @@ else {
                     Write-Output "$path doesn't exist. No action was taken."
                 }
             }
-            
-            
+
+
             Write-Output "Microsoft edge should be removed from your system."
             Write-Output "Please keep in mind microsoft edge webview has not been uninstalled. You can uninstall that in settings or control panel."
-
             continue
         }
         'RemoveAppsCustom' {

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1151,7 +1151,7 @@ else {
                 "$env:ProgramData\Microsoft\EdgeUpdate",
                 "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk",
                 "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk",
-                "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk"
+                "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk",
                 "$env:PUBLIC\Desktop\Microsoft Edge.lnk"
             )
             foreach ($path in $edgePaths){

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1012,8 +1012,10 @@ else {
             
             #give it a chance to uninstall itself before doing it forcefully
 
-            if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and ((winget -v) -replace 'v','' -gt 1.4)) {
-                $edgeNamesGet=@("Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe","Microsoft.MicrosoftEdge_8wekyb3d8bbwe","Microsoft.Edge","Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe","Microsoft Edge Update")
+            $ProgramFiles86=${env:ProgramFiles(x86)}
+
+            if ((Get-AppxPackage -Name "*Microsoft.DesktopAppInstaller*") -and (Test-Path -Path "$ProgramFiles86\Microsoft\Edge") -and ((winget -v) -replace 'v','' -gt 1.4)) {
+                $edgeNamesGet=@("Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe","Microsoft.Edge","Microsoft Edge Update")
 
                 foreach ($edge in $edgeNamesGet) {
                     try {
@@ -1026,15 +1028,11 @@ else {
 
                 Write-Output "Attempted to uninstall microsoft edge with winget"
             }else{
-                Write-Output "Looks like you don't have winget installed or your winget version is outdated. Attempting to remove microsoft edge without winget forcefully."
+                Write-Output "Microsoft edge was not found in winget."
             }
 
             Stop-Process -Name "*edge*" -Force
             Write-Output "Attempted to kill all microsoft edge processes"
-
-            # I don't know how these hashes work. I assume those update once microsoft edge updates that will be tons of pain keeping this edge remove function up to date - loadstring1
-
-            # my god microsoft edge leaves so much mess in the registry... - loadstring1
 
             # remove ms edge from autostart
             reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run" /v "MicrosoftEdgeAutoLaunch_A9F6DCE4ABADF4F51CF45CD7129E3C6C" /f
@@ -1045,69 +1043,6 @@ else {
             #remove ms edge from control panel and settings
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge" /f
             reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge Update" /f
-
-            # remove ms edge leftovers in registry
-            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Active Setup\Installed Components\{9459C573-B17A-45AE-9F64-1857B5D58CEE}" /f
-            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Clients\StartMenuInternet\Microsoft Edge" /f
-            reg delete "HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Internet Explorer\Low Rights\ElevationPolicy\{c9abcf16-8dc2-4a95-bae3-24fd98f2ed29}" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdge_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppModel\PolicyCache\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\WOW6432Node\CLSID\{FEAC932B-D6B2-40BF-B7C5-F35FAB41FCCA}\InprocHandler32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Edge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\EdgeUpdate" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\EdgeUpdateDev" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppHost\IndexedDB\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\AppHost\IndexedDB\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "AppX7rm9drdg8sk7vqndwj3sdjw11x96jc0y_microsoft-edge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "AppX3xxs313wwkfjhythsb8q46xdsq8d2cvv_microsoft-edge-holographic" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeMHT_.mht" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeMHT_.mhtml" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.svg" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.webp" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xht" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xhtml" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.xml" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_ftp" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_http" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_https" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.htm" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_.html" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_read" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_microsoft-edge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_microsoft-edge-holographic" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_ms-xbl-3d8b930f" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgePDF_.pdf" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ApplicationAssociationToasts" /v "MSEdgeHTM_mailto" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe" /f 
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\BackgroundAccessApplications\Microsoft.MicrosoftEdge_8wekyb3d8bbwe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\CapabilityAccessManager\ConsentStore\location\NonPackaged\C:#Program Files (x86)#Microsoft#Edge#Application#msedge.exe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppLaunch" /v "MSEdge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched" /v "{7C5A40EF-A0FB-4BFC-874A-C0F2E0B9FA8E}\\Microsoft\\EdgeUpdate\\MicrosoftEdgeUpdate.exe" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FeatureUsage\AppSwitched" /v "MSEdge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Feeds" /v "EdgeMUID" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe!App" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\PushNotifications\Backup\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!PdfReader" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\RunNotification" /v "StartupTNotiMicrosoft Edge Update" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Search\JumplistData" /v "MSEdge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\HostActivityManager\CommitHistory\Microsoft.MicrosoftEdge.Stable_8wekyb3d8bbwe!App" /f
-            reg delete "HKEY_CURRENT_USER\Software\Microsoft\Windows NT\CurrentVersion\HostActivityManager\CommitHistory\Microsoft.MicrosoftEdge_8wekyb3d8bbwe!MicrosoftEdge" /f
-            reg delete "HKEY_CURRENT_USER\Software\Wow6432Node\Microsoft\EdgeUpdateDev" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{1108FD1C-492F-4251-B9DB-77F0274267B2}\InProcServer32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{209222BB-556D-4EAF-9C53-4ACB9E51731C}\InprocHandler32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{5EA43877-C6D8-4885-B77A-C0BB27E94372}\InprocServer32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{6DD6748E-7DAE-47EF-B4D5-03AA1B06D697}\InProcServer32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{81093D63-7825-417B-BFC8-ADC63FA4E53D}\InprocServer32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{A8E2FC12-D508-44CC-AC5E-883746A1CA4C}\InprocHandler32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{B29F5F83-90DF-479A-BDE7-8A9F4412E394}\InProcServer32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\CLSID\{FEAC932B-D6B2-40BF-B7C5-F35FAB41FCCA}\InprocHandler32" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdgeDevToolsClient_8wekyb3d8bbwe%5Cresources.pri" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\MrtCache\C:%5CWindows%5CSystemApps%5CMicrosoft.MicrosoftEdge_8wekyb3d8bbwe%5Cresources.pri" /f
-            reg delete "HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\CurrentVersion\AppContainer\Storage\microsoft.microsoftedge.stable_8wekyb3d8bbwe" /f
-
-            #and there is way more than this i could do this all day but i think its enough i don't want to make this simple script 1k lines of code
 
 
             Write-Output "Attempted to remove microsoft edge from registry"
@@ -1120,13 +1055,11 @@ else {
             Write-Output "Attempted to remove microsoft edge from services"
 
             #remove leftover tasks
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateBrowserReplacementTask -Confirm:$false -ErrorAction SilentlyContinue
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineCore -Confirm:$false -ErrorAction SilentlyContinue
-            Unregister-ScheduledTask -TaskName MicrosoftEdgeUpdateTaskMachineUA -Confirm:$false -ErrorAction SilentlyContinue
+            Unregister-ScheduledTask -TaskName "*MicrosoftEdgeUpdateBrowserReplacementTask*" -Confirm:$false
+            Unregister-ScheduledTask -TaskName "*MicrosoftEdgeUpdateTaskMachineCore*" -Confirm:$false
+            Unregister-ScheduledTask -TaskName "*MicrosoftEdgeUpdateTaskMachineUA*" -Confirm:$false
 
             Write-Output "Attempted to remove microsoft edge from task scheduler"
-
-            $ProgramFiles86=${env:ProgramFiles(x86)}
 
             $edgePaths=@(
                 "$ProgramFiles86\Microsoft\Edge",
@@ -1140,7 +1073,8 @@ else {
                 "$env:ProgramData\Microsoft\Windows\Start Menu\Programs\Microsoft Edge.lnk",
                 "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\Microsoft Edge.lnk",
                 "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk",
-                "$env:PUBLIC\Desktop\Microsoft Edge.lnk"
+                "$env:PUBLIC\Desktop\Microsoft Edge.lnk",
+                "$env:USERPROFILE\Desktop\Microsoft Edge.lnk"
             )
             foreach ($path in $edgePaths){
                 if (Test-Path -Path $path) {


### PR DESCRIPTION
Tested and works on my windows 11 home 22h2 it wiped microsoft edge out of my system. I used closed-source programs to help myself with writing this feature.

**Please let me know if i should also consider force uninstalling edge webview and edge update because for now this is just edge uninstaller**

fixes this issue: [38](https://github.com/Raphire/Win11Debloat/issues/38)