### PR TITLE
Add support for -RemoveAppsCustom and -RunAppConfigurator while using the Quick method

### DIFF
--- a/Get.ps1
+++ b/Get.ps1
@@ -75,6 +75,14 @@ Expand-Archive "$env:TEMP/win11debloat-temp.zip" "$env:TEMP/Win11Debloat"
 # Remove archive
 Remove-Item "$env:TEMP/win11debloat-temp.zip"
 
+# Copy CustomAppsList to the Win11Debloat folder if it exists
+if (Test-Path "$PSScriptRoot/CustomAppsList") {
+    Write-Output ""
+    Write-Output "> Found CustomAppsList file"
+    Copy-Item "$PSScriptRoot/CustomAppsList" "$env:TEMP/Win11Debloat/CustomAppsList"
+}
+
+
 # Make list of arguments to pass on to the script
 $arguments = $($PSBoundParameters.GetEnumerator() | ForEach-Object {"-$($_.Key)"})
 

--- a/Get.ps1
+++ b/Get.ps1
@@ -90,7 +90,7 @@ Write-Output ""
 Write-Output "> Running Win11Debloat..."
 
 # Run Win11Debloat script with the provided arguments
-$debloatProcess = Start-Process powershell.exe -PassThru -ArgumentList "-executionpolicy bypass -File $env:TEMP\Win11Debloat\Win11Debloat-master\Win11Debloat.ps1 $arguments" -Verb RunAs
+$debloatProcess = Start-Process powershell.exe -PassThru -ArgumentList "-executionpolicy bypass -File $env:TEMP\Win11Debloat\Win11Debloat-master\Win11Debloat.ps1 $arguments -Quick" -Verb RunAs
 
 # Wait for the process to finish before continuing
 if ($null -ne $debloatProcess) {

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -728,7 +728,8 @@ if ($RunAppConfigurator) {
         Write-Host "App configurator was closed without saving." -ForegroundColor Red
     }
     else {
-        Write-Output "Your app selection was saved to the 'CustomAppsList' file in the root folder of the script."
+        Write-Output "Your app selection was saved to $PSScriptRoot\CustomAppsList. " + ` 
+        "If you're using the 'Quick method', be sure to move the file before continuing as the temp folder will be deleted."
     }
 
     AwaitKeyToExit

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -2,6 +2,7 @@
 
 [CmdletBinding(SupportsShouldProcess)]
 param (
+    [switch]$Quiet,
     [switch]$Silent,
     [switch]$Sysprep,
     [switch]$RunAppConfigurator,
@@ -728,8 +729,14 @@ if ($RunAppConfigurator) {
         Write-Host "App configurator was closed without saving." -ForegroundColor Red
     }
     else {
-        Write-Output "Your app selection was saved to $PSScriptRoot\CustomAppsList. " + ` 
-        "If you're using the 'Quick method', be sure to move the file before continuing as the temp folder will be deleted."
+        #  Move the file if running using Quick method which would otherwise delete the folder containing the file
+        if (-not $Quick) {
+            Write-Output "Your app selection was saved to the 'CustomAppsList' file in the root folder of the script."
+        }
+        else {
+            Move-Item "$PSScriptRoot/CustomAppsList" "$env:TEMP/CustomAppsList"
+            Write-Output "Your app selection was saved to '$env:TEMP/CustomAppsList'."
+        }
     }
 
     AwaitKeyToExit


### PR DESCRIPTION
This patch enables the use of `CustomAppsList` within the 'Quick method'. 

Currently, the 'Quick method' dynamically creates its working directory, making it impossible to include `CustomAppsList`, which is expected in the same directory as `Win11Debloat.ps1`. Also, using 'Quick method' to try to create the file using `-RunAppConfigurator` doesn't work since the file is created in the working folder which is deleted.

This update addresses this by:

* Checking for `CustomAppsList` in the directory where the 'Quick method' is initiated and copying it to the temporary folder.
* Checking if `-RunAppConfigurator` was used in the 'Quick method', and if so, moving the `CustomAppsList` file out of the temporary `Win11Debloat` directory to prevent it from being deleted when the script finishes. 