### PR TITLE
change the bat file name to Win11Debloat.bat

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Manually download & run the script.
 
 1. [Download the latest version of the script](https://github.com/Raphire/Win11Debloat/archive/master.zip), and extract the .ZIP file to your desired location.
 2. Navigate to the Win11Debloat folder
-3. Double click the `Run.bat` file to start the script. NOTE: If the console window immediately closes and nothing happens, try the advanced method below.
+3. Double click the `Win11Debloat.bat` file to start the script. NOTE: If the console window immediately closes and nothing happens, try the advanced method below.
 4. Accept the Windows UAC prompt to run the script as administrator, this is required for the script to function.
 5. A new PowerShell window will now open showing the Win11Debloat menu. Select either the default or custom mode to continue.
 6. Carefully read through and follow the on-screen instructions.

--- a/Run.bat
+++ b/Run.bat
@@ -1,1 +1,0 @@
-PowerShell -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File ""%~dp0Win11Debloat.ps1""' -Verb RunAs}"

--- a/Win11Debloat.bat
+++ b/Win11Debloat.bat
@@ -1,0 +1,1 @@
+PowerShell -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File ""%~dpn0.ps1""' -Verb RunAs}"


### PR DESCRIPTION
I think there was an upgrade at once @commit 9d07087. 
However, by changing from 「%~dp0Win11Debloat.ps1」 to 「%~dpn0.ps1」, you can upgrade the version again without making any changes to the content of the file, just by changing the file name.

![スクリーンショット 2024-08-31 174005](https://github.com/user-attachments/assets/fb0d7412-8a3c-4afe-be1b-6d1d9cf71146)