### PR TITLE
fix: use env:USERNAME

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -605,7 +605,7 @@ function ReplaceStartMenu {
         $startMenuTemplate = "$PSScriptRoot/Start/start2.bin"
     )
 
-    $userName = $startMenuBinFile.Split("\")[2]
+    $userName = $env:USERNAME
 
     # Check if template bin file exists, return early if it doesn't
     if (-not (Test-Path $startMenuTemplate)) {


### PR DESCRIPTION
Use the env username in the function to delete start menu items. 

I was in a situation where the home folder was auto generated when I installed windows, and I then switched to a local account with a different user name which caused this script to fail. 