### PR TITLE
Fix: Use regex replace to avoid #174

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -574,7 +574,7 @@ function ReplaceStartMenuForAllUsers {
     }
 
     # Get path to start menu file for all users
-    $userPathString = $env:USERPROFILE.Replace($env:USERNAME, "*\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState")
+    $userPathString = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), "*\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
     $usersStartMenuPaths = get-childitem -path $userPathString
 
     # Go through all users and replace the start menu file

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -574,7 +574,7 @@ function ReplaceStartMenuForAllUsers {
     }
 
     # Get path to start menu file for all users
-    $userPathString = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), "*\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
+    $userPathString = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), "\*\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
     $usersStartMenuPaths = get-childitem -path $userPathString
 
     # Go through all users and replace the start menu file

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -530,7 +530,7 @@ function RegImport {
         reg import "$PSScriptRoot\Regfiles\$path"  
     }
     else {
-        $defaultUserPath = $env:USERPROFILE.Replace($env:USERNAME, 'Default\NTUSER.DAT')
+        $defaultUserPath = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), '\Default\NTUSER.DAT'
         
         reg load "HKU\Default" $defaultUserPath | Out-Null
         reg import "$PSScriptRoot\Regfiles\Sysprep\$path"  
@@ -583,7 +583,7 @@ function ReplaceStartMenuForAllUsers {
     }
 
     # Also replace the start menu file for the default user profile
-    $defaultStartMenuPath = $env:USERPROFILE.Replace($env:USERNAME, 'Default\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState')
+    $defaultStartMenuPath = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), '\Default\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState'
 
     # Create folder if it doesn't exist
     if (-not(Test-Path $defaultStartMenuPath)) {
@@ -756,7 +756,7 @@ else {
 }
 
 if ($global:Params.ContainsKey("Sysprep")) {
-    $defaultUserPath = $env:USERPROFILE.Replace($env:USERNAME, 'Default\NTUSER.DAT')
+    $defaultUserPath = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), '\Default\NTUSER.DAT'
 
     # Exit script if default user directory or NTUSER.DAT file cannot be found
     if (-not (Test-Path "$defaultUserPath")) {


### PR DESCRIPTION
Change the function used to replace the result of `$userprofile` to `Default` from `.Replace()` to `-Replace` to enable use of Regex in matching to avoid #174.