### PR TITLE
Added option to run Win11Debloat as another user

### DIFF
--- a/Get.ps1
+++ b/Get.ps1
@@ -2,6 +2,7 @@ param (
     [switch]$Silent,
     [switch]$Verbose,
     [switch]$Sysprep,
+    [string]$User,
     [switch]$RunAppConfigurator,
     [switch]$RunDefaults, [switch]$RunWin11Defaults,
     [switch]$RunSavedSettings,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Win11Debloat is a simple, easy to use and lightweight PowerShell script that can remove pre-installed Windows bloatware apps, disable telemetry and declutter the experience by disabling or removing intrusive interface elements, ads and more. No need to painstakingly go through all the settings yourself or remove apps one by one. Win11Debloat makes the process quick and easy!
 
-The script also includes many features that system administrators will enjoy. Such as support for Windows Audit mode and the ability to run the script without requiring user input during runtime.
+ The script also includes many features that system administrators will enjoy. Such as support for Windows Audit mode, the option to make changes to other Windows users and the ability to run the script without requiring user input during runtime.
 
 ![Win11Debloat Menu](/Assets/menu.png)
 
@@ -59,6 +59,7 @@ The script also includes many features that system administrators will enjoy. Su
 
 - Disable Xbox game/screen recording, this also stops gaming overlay popups.
 - Turn off Enhance Pointer Precision, also known as mouse acceleration.
+- Option to apply changes to a different user, instead of the currently logged on user.
 - Sysprep mode to apply changes to the Windows Default user profile. Afterwards, all new users will have the changes automatically applied to them.
 
 ### Default Settings
@@ -299,6 +300,7 @@ The quick and advanced usage methods support switch parameters. A table of all t
 | :-------: | ----------- |
 | -Silent                             |    Suppresses all interactive prompts, so the script will run without requiring any user input. |
 | -Sysprep                            |    Run the script in Sysprep mode. All changes will be applied to the Windows default user profile and will only affect new user accounts. |
+| -User <USERNAME>                    |    Run the script for the specified user, instead of the logged in user. This user must have logged on atleast once, and cannot be logged at the time the script is run. |
 | -RunDefaults                        |    Run the script with the default settings. |
 | -RunSavedSettings                   |    Run the script with the saved custom settings from last time. These settings are saved to and read from the `SavedSettings` file in the root folder of the script. |
 | -RemoveApps                         |    Remove the default selection of bloatware apps. |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Win11Debloat is a simple, easy to use and lightweight PowerShell script that can remove pre-installed Windows bloatware apps, disable telemetry and declutter the experience by disabling or removing intrusive interface elements, ads and more. No need to painstakingly go through all the settings yourself or remove apps one by one. Win11Debloat makes the process quick and easy!
 
- The script also includes many features that system administrators will enjoy. Such as support for Windows Audit mode, the option to make changes to other Windows users and the ability to run the script without requiring user input during runtime.
+The script also includes many features that system administrators will enjoy. Such as support for Windows Audit mode, the option to make changes to other Windows users and the ability to run the script without requiring user input during runtime.
 
 ![Win11Debloat Menu](/Assets/menu.png)
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The script also includes many features that system administrators will enjoy. Su
 
 - Disable Xbox game/screen recording, this also stops gaming overlay popups.
 - Turn off Enhance Pointer Precision, also known as mouse acceleration.
-- Option to apply changes to a different user, instead of the currently logged on user.
+- Option to apply changes to a different user, instead of the currently logged in user.
 - Sysprep mode to apply changes to the Windows Default user profile. Afterwards, all new users will have the changes automatically applied to them.
 
 ### Default Settings
@@ -300,7 +300,7 @@ The quick and advanced usage methods support switch parameters. A table of all t
 | :-------: | ----------- |
 | -Silent                             |    Suppresses all interactive prompts, so the script will run without requiring any user input. |
 | -Sysprep                            |    Run the script in Sysprep mode. All changes will be applied to the Windows default user profile and will only affect new user accounts. |
-| -User `<USERNAME>`                  |    Run the script for the specified user, instead of the logged in user. This user must have logged on atleast once, and cannot be logged at the time the script is run. |
+| -User `<USERNAME>`                  |    Run the script for the specified user, instead of the currently logged in user. This user must have logged on atleast once, and cannot be logged in at the time the script is run. |
 | -RunDefaults                        |    Run the script with the default settings. |
 | -RunSavedSettings                   |    Run the script with the saved custom settings from last time. These settings are saved to and read from the `SavedSettings` file in the root folder of the script. |
 | -RemoveApps                         |    Remove the default selection of bloatware apps. |

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The quick and advanced usage methods support switch parameters. A table of all t
 | :-------: | ----------- |
 | -Silent                             |    Suppresses all interactive prompts, so the script will run without requiring any user input. |
 | -Sysprep                            |    Run the script in Sysprep mode. All changes will be applied to the Windows default user profile and will only affect new user accounts. |
-| -User <USERNAME>                    |    Run the script for the specified user, instead of the logged in user. This user must have logged on atleast once, and cannot be logged at the time the script is run. |
+| -User `<USERNAME>`                  |    Run the script for the specified user, instead of the logged in user. This user must have logged on atleast once, and cannot be logged at the time the script is run. |
 | -RunDefaults                        |    Run the script with the default settings. |
 | -RunSavedSettings                   |    Run the script with the saved custom settings from last time. These settings are saved to and read from the `SavedSettings` file in the root folder of the script. |
 | -RemoveApps                         |    Remove the default selection of bloatware apps. |

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1565,7 +1565,7 @@ else {
     Write-Output ""
     Write-Output ""
     Write-Output ""
-    Write-Output "Script completed successfully!"
+    Write-Output "Script completed! Please check above for any errors."
 
     AwaitKeyToExit
 }

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -646,7 +646,7 @@ function ReplaceStartMenu {
     # Copy template file
     Copy-Item -Path $startMenuTemplate -Destination $startMenuBinFile -Force
 
-     Write-Output "Replaced start menu for user$(GetUserName)"
+    Write-Output "Replaced start menu for user $(GetUserName)"
 }
 
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -552,7 +552,7 @@ function RegImport {
 
 # Restart the Windows Explorer process
 function RestartExplorer {
-    if ($global:Params.ContainsKey("Sysprep")) {
+    if ($global:Params.ContainsKey("Sysprep") -or $global:Params.ContainsKey("User")) {
         return
     }
 
@@ -622,6 +622,7 @@ function ReplaceStartMenu {
         $startMenuTemplate = "$PSScriptRoot/Start/start2.bin"
     )
 
+    # Change path to correct user if a user was specified
     if ($global:Params.ContainsKey("User")) {
         $startMenuBinFile = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), "\$(GetUserName)\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin"
     }
@@ -1151,7 +1152,7 @@ if ($global:Params.ContainsKey("User")) {
 
     # Exit script if user directory or NTUSER.DAT file cannot be found
     if (-not (Test-Path "$userPath")) {
-        Write-Host "Error: Unable to run Win11Debloat for user $($global:Params.Item("User")), cannot find user folder at '$userPath'" -ForegroundColor Red
+        Write-Host "Error: Unable to run Win11Debloat for user $($global:Params.Item("User")), cannot find user data at '$userPath'" -ForegroundColor Red
         AwaitKeyToExit
         Exit
     }

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -622,7 +622,9 @@ function ReplaceStartMenu {
         $startMenuTemplate = "$PSScriptRoot/Start/start2.bin"
     )
 
-    $userName = $env:USERNAME
+    if ($global:Params.ContainsKey("User")) {
+        $startMenuBinFile = $env:USERPROFILE -Replace ('\\' + $env:USERNAME + '$'), "\$(GetUserName)\AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin"
+    }
 
     # Check if template bin file exists, return early if it doesn't
     if (-not (Test-Path $startMenuTemplate)) {
@@ -632,7 +634,7 @@ function ReplaceStartMenu {
 
     # Check if bin file exists, return early if it doesn't
     if (-not (Test-Path $startMenuBinFile)) {
-        Write-Host "Error: Unable to clear start menu for user $userName, start2.bin file could not found" -ForegroundColor Red
+        Write-Host "Error: Unable to clear start menu for user $(GetUserName), start2.bin file could not found" -ForegroundColor Red
         return
     }
 
@@ -644,7 +646,7 @@ function ReplaceStartMenu {
     # Copy template file
     Copy-Item -Path $startMenuTemplate -Destination $startMenuBinFile -Force
 
-    Write-Output "Replaced start menu for user $userName"
+     Write-Output "Replaced start menu for user$(GetUserName)"
 }
 
 
@@ -720,6 +722,16 @@ function AwaitKeyToExit {
         Write-Output ""
         Write-Output "Press any key to exit..."
         $null = [System.Console]::ReadKey()
+    }
+}
+
+
+function GetUserName {
+    if ($global:Params.ContainsKey("User")) { 
+        return $global:Params.Item("User") 
+    } 
+    else { 
+        return $env:USERNAME 
     }
 }
 
@@ -873,7 +885,7 @@ function DisplayCustomModeOptions {
                 Do {
                     Write-Host "   Options:" -ForegroundColor Yellow
                     Write-Host "    (n) Don't remove any pinned apps from the start menu" -ForegroundColor Yellow
-                    Write-Host "    (1) Remove all pinned apps from the start menu for this user only ($env:USERNAME)" -ForegroundColor Yellow
+                    Write-Host "    (1) Remove all pinned apps from the start menu for this user only ($(GetUserName))" -ForegroundColor Yellow
                     Write-Host "    (2) Remove all pinned apps from the start menu for all existing and new users"  -ForegroundColor Yellow
                     $ClearStartInput = Read-Host "   Remove all pinned apps from the start menu? (n/1/2)" 
                 }
@@ -1440,7 +1452,7 @@ else {
             continue
         }
         'ClearStart' {
-            Write-Output "> Removing all pinned apps from the start menu for user $env:USERNAME..."
+            Write-Output "> Removing all pinned apps from the start menu for user $(GetUserName)..."
             ReplaceStartMenu
             Write-Output ""
             continue
@@ -1455,7 +1467,6 @@ else {
         }
         'TaskbarAlignLeft' {
             RegImport "> Aligning taskbar buttons to the left..." "Align_Taskbar_Left.reg"
-
             continue
         }
         'HideSearchTb' {


### PR DESCRIPTION
This version includes the option to run the script as another user, including users that are not administrator.

This works well in local environments from my testing, but I'm unsure how well this works within a domain. 

It's important to note this user needs to have logged into Windows atleast once. As the script needs access to the `NTUSER.DAT` file inside the user's directory. If you wish to apply changes to users before they have logged on, or before the user is created, please use the Sysprep mode instead.

If you wish to apply changes to newly created users or users that have not logged in yet, please use the Sysprep mode instead.

