### PR TITLE
Disable Modern Standby networking to prevent battery drain

### DIFF
--- a/Assets/Menus/DefaultSettings
+++ b/Assets/Menus/DefaultSettings
@@ -6,6 +6,7 @@ Win11Debloat will make the following changes:
 - Disable & remove Bing web search, Bing AI and Cortana from Windows search.
 - Disable & remove Microsoft Copilot. (W11 only)
 - Disable Fast Start-up to ensure a full shutdown.
+- Disable network connectivity during Modern Standby to prevent battery drain. (W11 only)
 - Show file extensions for known file types.
 - Hide the 3D objects folder in Windows Explorer. (W10 only)
 - Disable the widget service & hide the icon from the taskbar.

--- a/Get.ps1
+++ b/Get.ps1
@@ -19,6 +19,7 @@ param (
     [switch]$DisableDVR,
     [switch]$DisableTelemetry,
     [switch]$DisableFastStartup,
+    [switch]$DisableModernStandbyNetworking,
     [switch]$DisableBingSearches, [switch]$DisableBing,
     [switch]$DisableDesktopSpotlight,
     [switch]$DisableLockscrTips, [switch]$DisableLockscreenTips,

--- a/Regfiles/Disable_Modern_Standby_Networking.reg
+++ b/Regfiles/Disable_Modern_Standby_Networking.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9]
+"ACSettingIndex"=dword:00000000
+"DCSettingIndex"=dword:00000000

--- a/Regfiles/Sysprep/Disable_Modern_Standby_Networking.reg
+++ b/Regfiles/Sysprep/Disable_Modern_Standby_Networking.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9]
+"ACSettingIndex"=dword:00000000
+"DCSettingIndex"=dword:00000000

--- a/Regfiles/Undo/Enable_Modern_Standby_Networking.reg
+++ b/Regfiles/Undo/Enable_Modern_Standby_Networking.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9]
+"ACSettingIndex"=dword:00000001
+"DCSettingIndex"=dword:00000001


### PR DESCRIPTION
Fixes #268

Disables network connectivity during Modern Standby to prevent battery drain during sleep.

**Changes:**
- Add `DisableModernStandbyNetworking` parameter 
- Registry modification: `HKLM\SOFTWARE\Policies\Microsoft\Power\PowerSettings\f15576e8-98b7-4186-b944-eafa664402d9`
- Windows 11 only (build 22000+)
- Included in default settings
- Full undo support

**Usage:**
```
.\Win11Debloat.ps1 -DisableModernStandbyNetworking
```