### PR TITLE
Prompt user to restart script as administrator if not elevated

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -1,5 +1,3 @@
-#Requires -RunAsAdministrator
-
 [CmdletBinding(SupportsShouldProcess)]
 param (
     [switch]$CLI,
@@ -105,7 +103,22 @@ param (
     [switch]$HideDriveLetters
 )
 
+# Check if script is running as administrator
+$isAdmin = ([Security.Principal.WindowsPrincipal] `
+    [Security.Principal.WindowsIdentity]::GetCurrent()
+).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
+# If script is not running as administrator ask user if they want to allow it
+if (-not $isAdmin) {
+    Write-Host "This script must be run as Administrator." -ForegroundColor Red
+
+    $choice = Read-Host "Restart as Administrator? (Y/N)"
+
+    if ($choice -match '^[Yy]$') {
+        Start-Process powershell -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs
+    }
+    exit
+}
 
 # Define script-level variables & paths
 $script:Version = "2026.04.05"


### PR DESCRIPTION
Removes #Requires -RunAsAdministrator and adds a check that prompts
the user to restart the script with elevated privileges if needed.