### PR TITLE
New Service Addition (Disc #547): Disable Update Service

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1359,6 +1359,21 @@
       "MinVersion": null,
       "MaxVersion": null
     },
+
+    {
+      "FeatureId": "Disablewuaserv",
+      "Label": "Disable Windows Update Service",
+      "ToolTip": "This will attempt to disable the updating service on a loop. When paired with other options like preventing idle detection, it can permanently stop updates.",
+      "Category": "Windows Update",
+      "Action": "",
+      "RegistryKey": null,
+      "ApplyText": "Disabling wuaserv.",
+      "UndoAction": "Get",
+      "RegistryUndoKey": null,
+      "MinVersion": null,
+      "MaxVersion": null
+    },
+
     {
       "FeatureId": "PreventUpdateAutoReboot",
       "Label": "automatic restarts after updates while signed in",

--- a/Scripts/Features/Disablewuaserv.ps1
+++ b/Scripts/Features/Disablewuaserv.ps1
@@ -1,0 +1,22 @@
+function Disablewuaserv {
+$ServiceName = "wuauserv"
+
+# Check for admin
+$currentIdentity = [Security.Principal.WindowsIdentity]::GetCurrent()
+$principal = New-Object Security.Principal.WindowsPrincipal($currentIdentity)
+if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Host "Error from Win11Debloat Component: This script requires administrative privileges. Please run as administrator."
+    exit 1
+}
+
+while ($true) {
+    try {
+        Stop-Service -Name $ServiceName -Force -ErrorAction Stop
+        Stop-Service -Name $ServiceName -Force -ErrorAction Stop
+    }
+    catch {
+        Write-Host "NO HIT: $_"
+    }
+ping 127.0.0.1 -n 1 -l 1 >nul # For preventing idle detection. Normally one might use a macro exe, but it could be too invasive for a commerical product. 
+}
+}

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -32,6 +32,7 @@ param (
     [switch]$DisableModernStandbyNetworking,
     [switch]$DisableStorageSense,
     [switch]$DisableUpdateASAP,
+	[switch]$Disablewuaserv,
     [switch]$PreventUpdateAutoReboot,
     [switch]$DisableDeliveryOptimization,
     [switch]$DisableBing,
@@ -274,7 +275,7 @@ if (-not $script:WingetInstalled -and -not $Silent) {
 . "$PSScriptRoot/Scripts/AppRemoval/ForceRemoveEdge.ps1"
 . "$PSScriptRoot/Scripts/AppRemoval/RemoveApps.ps1"
 . "$PSScriptRoot/Scripts/AppRemoval/GetInstalledAppsViaWinget.ps1"
-
+. "$PSScriptRoot/Scripts/Features/Disablewuaserv.ps1"
 # CLI functions
 . "$PSScriptRoot/Scripts/CLI/AwaitKeyToExit.ps1"
 . "$PSScriptRoot/Scripts/CLI/ShowCLILastUsedSettings.ps1"  


### PR DESCRIPTION
Hello, 

A little while back, I wrote [**"Improve Privacy and Update Control #547"**](https://github.com/Raphire/Win11Debloat/discussions/547) in your discussion board and suggested some changes. I've begun producing them, I decided to split these into 2 prs. This one covers the update service, while the other one will cover the privacy section. 

This one is a bit more polarizing and the most 'crude but pragmatic' solution of the bunch, My other solutions are much more easily streamlined by the system and already fit your scripts goals, so I think separating it from this PR is in all of our best interests. 

This all being said, I have tested it and it seems to work. However, I actually have windows 10, so my testing is not ironclad. I'd definitely recommend testing this before addition as I troubleshooted the process of creation on a Windows 10 machine.  