### PR TITLE
Fix: Increase System Restore point creation timeout to 90 seconds

### DIFF
--- a/Scripts/Features/CreateSystemRestorePoint.ps1
+++ b/Scripts/Features/CreateSystemRestorePoint.ps1
@@ -6,7 +6,6 @@ function CreateSystemRestorePoint {
         # In GUI mode, skip the prompt and just try to enable it
         if ($script:GuiWindow -or $Silent -or $( Read-Host -Prompt "System restore is disabled, would you like to enable it and create a restore point? (y/n)") -eq 'y') {
             try {
-                # Changed it from 20 seconds to 90 for slow computers, and maybe 120 is great
                 $enableResult = Invoke-NonBlocking -TimeoutSeconds 90 -ScriptBlock {
                     try {
                         Enable-ComputerRestore -Drive "$env:SystemDrive"
@@ -34,7 +33,6 @@ function CreateSystemRestorePoint {
 
     if (-not $failed) {
         try {
-            # Changed it from 20 seconds to 90 for slow computers, and maybe 120 is great
             $result = Invoke-NonBlocking -TimeoutSeconds 90 -ScriptBlock {
                 try {
                     $recentRestorePoints = Get-ComputerRestorePoint | Where-Object { (Get-Date) - [System.Management.ManagementDateTimeConverter]::ToDateTime($_.CreationTime) -le (New-TimeSpan -Hours 24) }

--- a/Scripts/Features/CreateSystemRestorePoint.ps1
+++ b/Scripts/Features/CreateSystemRestorePoint.ps1
@@ -6,7 +6,8 @@ function CreateSystemRestorePoint {
         # In GUI mode, skip the prompt and just try to enable it
         if ($script:GuiWindow -or $Silent -or $( Read-Host -Prompt "System restore is disabled, would you like to enable it and create a restore point? (y/n)") -eq 'y') {
             try {
-                $enableResult = Invoke-NonBlocking -TimeoutSeconds 20 -ScriptBlock {
+                # Changed it from 20 seconds to 90 for slow computers, and maybe 120 is great
+                $enableResult = Invoke-NonBlocking -TimeoutSeconds 90 -ScriptBlock {
                     try {
                         Enable-ComputerRestore -Drive "$env:SystemDrive"
                         return $null
@@ -33,7 +34,8 @@ function CreateSystemRestorePoint {
 
     if (-not $failed) {
         try {
-            $result = Invoke-NonBlocking -TimeoutSeconds 20 -ScriptBlock {
+            # Changed it from 20 seconds to 90 for slow computers, and maybe 120 is great
+            $result = Invoke-NonBlocking -TimeoutSeconds 90 -ScriptBlock {
                 try {
                     $recentRestorePoints = Get-ComputerRestorePoint | Where-Object { (Get-Date) - [System.Management.ManagementDateTimeConverter]::ToDateTime($_.CreationTime) -le (New-TimeSpan -Hours 24) }
                 }

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -166,7 +166,7 @@ function ExecuteAllChanges {
     if ($hasRegistryBackedFeature) {
         $currentStep++
         if ($script:ApplyProgressCallback) {
-            & $script:ApplyProgressCallback $currentStep $totalSteps "Creating registry backup"
+            & $script:ApplyProgressCallback $currentStep $totalSteps "Creating registry backup..."
         }
 
         Write-Host "> Creating registry backup..."
@@ -182,9 +182,9 @@ function ExecuteAllChanges {
     if ($script:Params.ContainsKey("CreateRestorePoint")) {
         $currentStep++
         if ($script:ApplyProgressCallback) {
-            & $script:ApplyProgressCallback $currentStep $totalSteps "Creating system restore point"
+            & $script:ApplyProgressCallback $currentStep $totalSteps "Creating system restore point, this may take a moment..."
         }
-        Write-Host "> Attempting to create a system restore point..."
+        Write-Host "> Creating a system restore point..."
         CreateSystemRestorePoint
         Write-Host ""
     }


### PR DESCRIPTION
This PR addresses an issue where the `CreateSystemRestorePoint` function fails prematurely due to a strict 20-second timeout. 

On slower storage drives, or when Windows has pending background updates, creating a Volume Shadow Copy snapshot organically takes longer than 20 seconds. This causes the script to abort the backup and throw an error. 

### Changes Made
* Updated `CreateSystemRestorePoint.ps1`
* Increased `-TimeoutSeconds` from `20` to `90` on both the `Enable-ComputerRestore` block and the `Checkpoint-Computer` block.
* This gives the system adequate time to process the shadow copy without locking up the script indefinitely.

Fixes #584