### PR TITLE
Prevent SSID Trilateration Through New Checkbox

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -374,6 +374,20 @@
       "MinVersion": null,
       "MaxVersion": null
     },
+
+    {
+      "FeatureId": "DisableWiFi",
+      "Label": "Disable Wi-Fi Service (prevent location leaking when disabled).",
+      "ToolTip": "Even with location services disabled and going through extensive effort, it is all in vain if you leave Wi-Fi and Wi-Fi discovery enabled. Wi-Fi trilateration via discoverable SSIDs nearby can leak your location.",
+      "Category": "Privacy & Suggested Content",
+      "RegistryKey": null,
+      "ApplyText": "Disabling the Wi-Fi service and monitoring it (keeping it disabled)...",
+      "UndoAction": "Enable", 
+      "RegistryUndoKey": null,
+      "MinVersion": null,
+      "MaxVersion": null
+    },
+    
     {
       "FeatureId": "DisableSuggestions",
       "Label": "Disable tips, tricks & suggested content throughout Windows",

--- a/Scripts/Features/DisableWiFi.ps1
+++ b/Scripts/Features/DisableWiFi.ps1
@@ -1,0 +1,22 @@
+function DisableWiFi {
+while ($true) {
+if (-not ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+    [Security.Principal.WindowsBuiltInRole]::Administrator
+)) {
+    throw "This script must be run as Administrator."
+}
+
+    Start-Sleep -Seconds 2
+
+    $wifiAdapters = Get-NetAdapter -Physical -IncludeHidden |
+        Where-Object {
+            ($_.NdisPhysicalMedium -in 1, 9 -or
+            $_.InterfaceDescription -match 'Wi-?Fi|Wireless|WLAN|802\.11') -and
+            $_.Status -eq 'Up'
+         }
+
+    if ($wifiAdapters) {
+        $wifiAdapters | Disable-NetAdapter -Confirm:$false
+     }
+ }
+ }

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -119,6 +119,12 @@ function ExecuteParameter {
             ReplaceStartMenuForAllUsers $script:Params.Item("ReplaceStartAllUsers")
             return
         }
+
+        'DisableWiFi' {
+            DisableWiFi $script:Params.Item("DisableWiFi")
+            return
+        }
+
         'DisableStoreSearchSuggestions' {
             if ($script:Params.ContainsKey("Sysprep")) {
                 Write-Host "> Disabling Microsoft Store search suggestions in the start menu for all users..."

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -36,6 +36,7 @@ param (
     [switch]$DisableDeliveryOptimization,
     [switch]$DisableBing,
     [switch]$DisableStoreSearchSuggestions,
+    [switch]$DisableWiFi,
     [switch]$DisableSearchHighlights,
     [switch]$DisableDesktopSpotlight,
     [switch]$DisableLockscreenTips,
@@ -306,6 +307,7 @@ if (-not $script:WingetInstalled -and -not $Silent) {
 . "$PSScriptRoot/Scripts/Features/ImportRegistryFile.ps1"
 . "$PSScriptRoot/Scripts/Features/ReplaceStartMenu.ps1"
 . "$PSScriptRoot/Scripts/Features/RestartExplorer.ps1"
+. "$PSScriptRoot/Scripts/Features/DisableWiFi.ps1"
 
 # File I/O functions
 . "$PSScriptRoot/Scripts/FileIO/LoadJsonFile.ps1"


### PR DESCRIPTION
Hello, 

**Tl;dr** Inert powershell script Disables the wifi service when function called by delegator Win11Debloat.ps1, repeatedly checks if Wi-Fi is enabled and disables it if it is. Integrated with Functions.json, executechanges.ps1, [added file]DisableWifi.ps1, and Win11debloat.ps1

**Why beneficial:** 

I wrote [Discussion 547](https://github.com/Raphire/Win11Debloat/discussions/547) where I mentioned two potential features to add to your service. One of them already has a concluded PR, this is the other feature. 

The Wifi service is heavily logged by Microsoft, if it is enabled it will often negate turning off location services. You can actually test this through an interesting method: turn off location services on your host machine, then make a windows 10 virtual machine and leave 'find my location on' with your wifi still running on your host machine. In theory, it shouldn't be able to find your location, but it will, go on edge on the vm and look up "whats my location" and give the site permission. And yes to clarify this assumes the VM runs through its own adapter, ie the Virtualbox hypervisor's adapter.

Obviously I understand that not everyone can disable their Wifi, but this optional feature will be beneficial for those who can. 

**PS** If someone can't use ethernet the user could also bypass Wi-fi through a usb tether with a secure device (ie a phone) connected to the wi-fi the computer would've connected to. A "pseudo-wired" connection. 