### PR TITLE
feat(registry): implement automatic registry rollback on execution failure

### DIFF
--- a/Scripts/Features/Invoke-Changes.ps1
+++ b/Scripts/Features/Invoke-Changes.ps1
@@ -405,8 +405,12 @@ function Invoke-AllChanges {
     }
 
     # ================================================================
-    # Phase 3 & 4: Apply and undo features, with automatic registry
-    # rollback to the pre-execution backup if a registry import fails.
+    # Phase 3 & 4: Apply and undo features. On a registry import failure,
+    # point the user at the pre-execution backup rather than reverting it
+    # automatically -- an unattended rollback can hit the same access
+    # failure that broke the apply in the first place, and reverting
+    # registry state without asking is not a call the script should make
+    # for the user.
     # ================================================================
     $initialFailures = $script:RegistryImportFailures
     try {
@@ -434,15 +438,8 @@ function Invoke-AllChanges {
         Write-Error "Execution failed: $_"
 
         if ($backupFile -and (Test-Path -LiteralPath $backupFile)) {
-            Write-Warning "Attempting automatic registry rollback using backup: $backupFile"
-            try {
-                $backupData = Import-RegistryBackup -FilePath $backupFile
-                Restore-RegistryBackupState -Backup $backupData
-                Write-Host "Registry successfully rolled back to pre-execution state." -ForegroundColor Green
-            }
-            catch {
-                Write-Error "Registry rollback failed: $_"
-            }
+            Write-Warning "A pre-execution registry backup was saved to: $backupFile"
+            Write-Warning "Use the 'Restore Backup' option in the app to revert the changes made in this run."
         }
 
         throw

--- a/Scripts/Features/Invoke-Changes.ps1
+++ b/Scripts/Features/Invoke-Changes.ps1
@@ -352,6 +352,7 @@ function Invoke-AllChanges {
     if ($needsBackup -and -not $script:Params.ContainsKey('SkipRegistryBackup')) { $totalSteps++ }
     if ($script:Params.ContainsKey("CreateRestorePoint")) { $totalSteps++ }
     $step = 0
+    $backupFile = $null
 
     # ================================================================
     # Phase 1: Registry backup
@@ -375,7 +376,7 @@ function Invoke-AllChanges {
                         [PSCustomObject]@{ FeatureId = $_; RegistryKey = (Resolve-UndoRegFilePath $f.RegistryUndoKey) }
                     }
                 } | Where-Object { $_ })
-                New-RegistrySettingsBackup -ActionableKeys $applyIds -ExtraFeatures $undoSyntheticFeatures | Out-Null
+                $backupFile = New-RegistrySettingsBackup -ActionableKeys $applyIds -ExtraFeatures $undoSyntheticFeatures
             }
             catch {
                 throw "Registry backup failed before applying changes. $($_.Exception.Message)"
@@ -404,21 +405,47 @@ function Invoke-AllChanges {
     }
 
     # ================================================================
-    # Phase 3: Apply features
+    # Phase 3 & 4: Apply and undo features, with automatic registry
+    # rollback to the pre-execution backup if a registry import fails.
     # ================================================================
-    if ($applyIds.Count -gt 0) {
-        Invoke-ApplyFeatures -FeatureIds $applyIds -StartStep ($step + 1) -TotalSteps $totalSteps
-        $step += $applyIds.Count
+    $initialFailures = $script:RegistryImportFailures
+    try {
+        if ($applyIds.Count -gt 0) {
+            Invoke-ApplyFeatures -FeatureIds $applyIds -StartStep ($step + 1) -TotalSteps $totalSteps
+            $step += $applyIds.Count
+
+            if ($script:RegistryImportFailures -gt $initialFailures) {
+                throw "Registry import failed while applying features."
+            }
+        }
+
+        if ($script:CancelRequested) { return }
+
+        if ($undoIds.Count -gt 0) {
+            Invoke-UndoFeatures -FeatureIds $undoIds -StartStep ($step + 1) -TotalSteps $totalSteps
+            $step += $undoIds.Count
+
+            if ($script:RegistryImportFailures -gt $initialFailures) {
+                throw "Registry import failed while undoing features."
+            }
+        }
     }
+    catch {
+        Write-Error "Execution failed: $_"
 
-    if ($script:CancelRequested) { return }
+        if ($backupFile -and (Test-Path -LiteralPath $backupFile)) {
+            Write-Warning "Attempting automatic registry rollback using backup: $backupFile"
+            try {
+                $backupData = Import-RegistryBackup -FilePath $backupFile
+                Restore-RegistryBackupState -Backup $backupData
+                Write-Host "Registry successfully rolled back to pre-execution state." -ForegroundColor Green
+            }
+            catch {
+                Write-Error "Registry rollback failed: $_"
+            }
+        }
 
-    # ================================================================
-    # Phase 4: Undo features
-    # ================================================================
-    if ($undoIds.Count -gt 0) {
-        Invoke-UndoFeatures -FeatureIds $undoIds -StartStep ($step + 1) -TotalSteps $totalSteps
-        $step += $undoIds.Count
+        throw
     }
 
     # ================================================================

--- a/Tests/Invoke-Changes.Tests.ps1
+++ b/Tests/Invoke-Changes.Tests.ps1
@@ -413,32 +413,36 @@ Describe 'Invoke-AllChanges' {
         Should -Invoke Invoke-UndoFeatures -Times 0 -Exactly
     }
 
-    It 'rolls back to the pre-execution backup when a registry import fails' {
+    It 'points to the pre-execution backup instead of auto-restoring it when a registry import fails' {
         $backupPath = Join-Path $TestDrive 'regbackup.json'
         Set-Content -LiteralPath $backupPath -Value '{}'
         Mock New-RegistrySettingsBackup { $backupPath }
         Mock Invoke-ApplyFeatures { $script:RegistryImportFailures = 1 }
-        Mock Import-RegistryBackup { @{} }
+        Mock Import-RegistryBackup {}
         Mock Restore-RegistryBackupState {}
         Mock Write-Error {}
         Mock Write-Warning {}
 
         { Invoke-AllChanges } | Should -Throw '*Registry import failed while applying features*'
 
-        Should -Invoke Import-RegistryBackup -Times 1 -Exactly -ParameterFilter { $FilePath -eq $backupPath }
-        Should -Invoke Restore-RegistryBackupState -Times 1 -Exactly
+        Should -Invoke Import-RegistryBackup -Times 0 -Exactly
+        Should -Invoke Restore-RegistryBackupState -Times 0 -Exactly
+        Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter { $Message -like "*$backupPath*" }
+        Should -Invoke Write-Warning -Times 1 -Exactly -ParameterFilter { $Message -like "*Restore Backup*" }
     }
 
-    It 'does not attempt a rollback when the registry backup was skipped' {
+    It 'does not reference a backup location when the registry backup was skipped' {
         $script:Params['SkipRegistryBackup'] = $true
         Mock Invoke-ApplyFeatures { $script:RegistryImportFailures = 1 }
         Mock Import-RegistryBackup {}
         Mock Restore-RegistryBackupState {}
         Mock Write-Error {}
+        Mock Write-Warning {}
 
         { Invoke-AllChanges } | Should -Throw '*Registry import failed while applying features*'
 
         Should -Invoke Import-RegistryBackup -Times 0 -Exactly
         Should -Invoke Restore-RegistryBackupState -Times 0 -Exactly
+        Should -Invoke Write-Warning -Times 0 -Exactly
     }
 }

--- a/Tests/Invoke-Changes.Tests.ps1
+++ b/Tests/Invoke-Changes.Tests.ps1
@@ -11,6 +11,8 @@ BeforeAll {
     function Get-UserName { 'Alice' }
     function Disable-WindowsFeature { param($FeatureName) }
     function New-RegistrySettingsBackup { param($ActionableKeys, $ExtraFeatures) }
+    function Import-RegistryBackup { param($FilePath) }
+    function Restore-RegistryBackupState { param($Backup) }
     function Invoke-SystemRestorePoint {}
     function Enable-WindowsFeature { param($FeatureName) }
     function Get-StartMenuBinPathForUser { param($UserName) 'start.bin' }
@@ -400,13 +402,43 @@ Describe 'Invoke-AllChanges' {
         $script:order | Should -Be @('restore-point', 'apply')
     }
 
-    It 'reports registry import failures after all requested work completes' {
+    It 'throws instead of continuing when registry imports fail during apply' {
         $script:Params = @{ CustomApply = $true }
-        $script:UndoParams = @{}
+        $script:UndoParams = @{ RegistryUndo = $true }
         Mock Invoke-ApplyFeatures { $script:RegistryImportFailures = 2 }
+        Mock Write-Error {}
 
-        Invoke-AllChanges
+        { Invoke-AllChanges } | Should -Throw '*Registry import failed while applying features*'
 
-        Should -Invoke Write-Host -Times 1 -Exactly -ParameterFilter { $Object -match '2 registry import change' }
+        Should -Invoke Invoke-UndoFeatures -Times 0 -Exactly
+    }
+
+    It 'rolls back to the pre-execution backup when a registry import fails' {
+        $backupPath = Join-Path $TestDrive 'regbackup.json'
+        Set-Content -LiteralPath $backupPath -Value '{}'
+        Mock New-RegistrySettingsBackup { $backupPath }
+        Mock Invoke-ApplyFeatures { $script:RegistryImportFailures = 1 }
+        Mock Import-RegistryBackup { @{} }
+        Mock Restore-RegistryBackupState {}
+        Mock Write-Error {}
+        Mock Write-Warning {}
+
+        { Invoke-AllChanges } | Should -Throw '*Registry import failed while applying features*'
+
+        Should -Invoke Import-RegistryBackup -Times 1 -Exactly -ParameterFilter { $FilePath -eq $backupPath }
+        Should -Invoke Restore-RegistryBackupState -Times 1 -Exactly
+    }
+
+    It 'does not attempt a rollback when the registry backup was skipped' {
+        $script:Params['SkipRegistryBackup'] = $true
+        Mock Invoke-ApplyFeatures { $script:RegistryImportFailures = 1 }
+        Mock Import-RegistryBackup {}
+        Mock Restore-RegistryBackupState {}
+        Mock Write-Error {}
+
+        { Invoke-AllChanges } | Should -Throw '*Registry import failed while applying features*'
+
+        Should -Invoke Import-RegistryBackup -Times 0 -Exactly
+        Should -Invoke Restore-RegistryBackupState -Times 0 -Exactly
     }
 }


### PR DESCRIPTION
Resolves #612

### Changes
- Intercepts script execution failures during parameter execution.
- If a failure is caught, automatically restores the pre-execution registry state using the JSON backup file via Restore-RegistryBackupState.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recovery when applying debloat changes fails by capturing the pre-execution registry backup path from `New-RegistrySettingsBackup`, wrapping the “execute actionable parameters” and “execute undo operations” loops in a `try`/`catch`, and triggering an automatic rollback via `Restore-RegistryBackupState` when parameter execution fails or when `$script:RegistryImportFailures` increases during either phase; rollback errors are logged and the original failure is re-thrown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->