### PR TITLE
feat(telemetry): disable telemetry-related scheduled tasks under Microsoft\Windows

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -393,9 +393,9 @@
       "ToolTip": "This setting disables telemetry, diagnostic data collection, activity history, app-launch tracking, targeted ads and more. It limits the data that is sent to Microsoft about your device and usage. If you are a Windows Insider, updates may be blocked until optional diagnostic data collection is turned back on.",
       "Category": "Privacy & Suggested Content",
       "RegistryKey": "Disable_Telemetry.reg",
-      "ApplyText": "Disabling telemetry, diagnostic data, activity history, app-launch tracking and targeted ads",
+      "ApplyText": "Disabling telemetry and diagnostic data collection",
       "UndoLabel": "Enable telemetry, tracking & targeted ads",
-      "ApplyUndoText": "Enabling telemetry, diagnostic data, activity history, app-launch tracking and targeted ads",
+      "ApplyUndoText": "Enabling telemetry and diagnostic data collection",
       "RegistryUndoKey": "Enable_Telemetry.reg",
       "MinVersion": null,
       "MaxVersion": null

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -334,8 +334,13 @@ function Disable-TelemetryScheduledTasks {
                     Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
                 }
                 else {
-                    Disable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue | Out-Null
-                    Write-Host "Disabled Scheduled Task: $($task.Path)\$($task.Name)"
+                    try {
+                        Disable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction Stop | Out-Null
+                        Write-Host "Disabled Scheduled Task: $($task.Path)\$($task.Name)"
+                    }
+                    catch {
+                        Write-Host "Failed to disable Scheduled Task: $($task.Path)\$($task.Name) - $($_.Exception.Message)" -ForegroundColor Yellow
+                    }
                 }
             }
             else {

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -249,6 +249,12 @@ function ExecuteAllChanges {
 
         if ($f -and $f.RegistryUndoKey) {
             ImportRegistryFile "> $applyUndoText" (Resolve-UndoRegFilePath $f.RegistryUndoKey)
+            switch ($featureId) {
+                'DisableTelemetry' {
+                    # Also re-enable telemetry scheduled tasks
+                    Enable-TelemetryScheduledTasks
+                }
+            }
         } else {
             Invoke-UndoFeatureAction -FeatureId $featureId
         }
@@ -317,6 +323,7 @@ function Invoke-UndoFeatureAction {
 function Disable-TelemetryScheduledTasks {
     $tasks = @(
         @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser Exp" },
         @{ Path = "\Microsoft\Windows\Application Experience"; Name = "ProgramDataUpdater" },
         @{ Path = "\Microsoft\Windows\Application Experience"; Name = "StartupAppTask" },
         @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "Consolidator" },
@@ -326,11 +333,12 @@ function Disable-TelemetryScheduledTasks {
     )
 
     Write-Host "> Disabling telemetry scheduled tasks..."
+    $isWhatIf = $WhatIfPreference -or ($null -ne $script:Params -and $script:Params.ContainsKey("WhatIf"))
     foreach ($task in $tasks) {
         $taskObj = Get-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue
         if ($taskObj) {
             if ($taskObj.State -ne 'Disabled') {
-                if ($WhatIfPreference) {
+                if ($isWhatIf) {
                     Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
                 }
                 else {
@@ -345,6 +353,48 @@ function Disable-TelemetryScheduledTasks {
             }
             else {
                 Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) is already disabled."
+            }
+        }
+        else {
+            Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) not found."
+        }
+    }
+    Write-Host ""
+}
+
+function Enable-TelemetryScheduledTasks {
+    $tasks = @(
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser Exp" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "ProgramDataUpdater" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "StartupAppTask" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "Consolidator" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "UsbCeip" },
+        @{ Path = "\Microsoft\Windows\DiskDiagnostic"; Name = "Microsoft-Windows-DiskDiagnosticDataCollector" },
+        @{ Path = "\Microsoft\Windows\Autochk"; Name = "Proxy" }
+    )
+
+    Write-Host "> Enabling telemetry scheduled tasks..."
+    $isWhatIf = $WhatIfPreference -or ($null -ne $script:Params -and $script:Params.ContainsKey("WhatIf"))
+    foreach ($task in $tasks) {
+        $taskObj = Get-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue
+        if ($taskObj) {
+            if ($taskObj.State -eq 'Disabled') {
+                if ($isWhatIf) {
+                    Write-Host "[WhatIf] Enable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
+                }
+                else {
+                    try {
+                        Enable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction Stop | Out-Null
+                        Write-Host "Enabled Scheduled Task: $($task.Path)\$($task.Name)"
+                    }
+                    catch {
+                        Write-Host "Failed to enable Scheduled Task: $($task.Path)\$($task.Name) - $($_.Exception.Message)" -ForegroundColor Yellow
+                    }
+                }
+            }
+            else {
+                Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) is already enabled."
             }
         }
         else {

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -309,6 +309,7 @@ function Invoke-UndoFeatureAction {
         'DisableTelemetry' {
             # Also re-enable telemetry scheduled tasks
             Enable-TelemetryScheduledTasks
+            return
         }
     }
 }

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -26,6 +26,10 @@ function ExecuteParameter {
                 # Also remove the app package for Copilot
                 RemoveApps @('Microsoft.Copilot')
             }
+            'DisableTelemetry' {
+                # Also disable telemetry scheduled tasks
+                Disable-TelemetryScheduledTasks
+            }
         }
         return
     }
@@ -308,4 +312,39 @@ function Invoke-UndoFeatureAction {
             return
         }
     }
+}
+
+function Disable-TelemetryScheduledTasks {
+    $tasks = @(
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "ProgramDataUpdater" },
+        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "StartupAppTask" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "Consolidator" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "UsbCeip" },
+        @{ Path = "\Microsoft\Windows\DiskDiagnostic"; Name = "Microsoft-Windows-DiskDiagnosticDataCollector" },
+        @{ Path = "\Microsoft\Windows\Autochk"; Name = "Proxy" }
+    )
+
+    Write-Host "> Disabling telemetry scheduled tasks..."
+    foreach ($task in $tasks) {
+        $taskObj = Get-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue
+        if ($taskObj) {
+            if ($taskObj.State -ne 'Disabled') {
+                if ($WhatIfPreference) {
+                    Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
+                }
+                else {
+                    Disable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue | Out-Null
+                    Write-Host "Disabled Scheduled Task: $($task.Path)\$($task.Name)"
+                }
+            }
+            else {
+                Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) is already disabled."
+            }
+        }
+        else {
+            Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) not found."
+        }
+    }
+    Write-Host ""
 }

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -249,15 +249,9 @@ function ExecuteAllChanges {
 
         if ($f -and $f.RegistryUndoKey) {
             ImportRegistryFile "> $applyUndoText" (Resolve-UndoRegFilePath $f.RegistryUndoKey)
-            switch ($featureId) {
-                'DisableTelemetry' {
-                    # Also re-enable telemetry scheduled tasks
-                    Enable-TelemetryScheduledTasks
-                }
-            }
-        } else {
-            Invoke-UndoFeatureAction -FeatureId $featureId
         }
+        
+        Invoke-UndoFeatureAction -FeatureId $featureId
     }
 
     if ($script:RegistryImportFailures -gt 0) {
@@ -312,94 +306,9 @@ function Invoke-UndoFeatureAction {
             Write-Host ""
             return
         }
-        default {
-            Write-Host "> No undo action defined for $FeatureId, skipping..." -ForegroundColor Yellow
-            Write-Host ""
-            return
+        'DisableTelemetry' {
+            # Also re-enable telemetry scheduled tasks
+            Enable-TelemetryScheduledTasks
         }
     }
-}
-
-function Disable-TelemetryScheduledTasks {
-    $tasks = @(
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser Exp" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "ProgramDataUpdater" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "StartupAppTask" },
-        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "Consolidator" },
-        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "UsbCeip" },
-        @{ Path = "\Microsoft\Windows\DiskDiagnostic"; Name = "Microsoft-Windows-DiskDiagnosticDataCollector" },
-        @{ Path = "\Microsoft\Windows\Autochk"; Name = "Proxy" }
-    )
-
-    Write-Host "> Disabling telemetry scheduled tasks..."
-    $isWhatIf = $WhatIfPreference -or ($null -ne $script:Params -and $script:Params.ContainsKey("WhatIf"))
-    foreach ($task in $tasks) {
-        $taskObj = Get-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue
-        if ($taskObj) {
-            if ($taskObj.State -ne 'Disabled') {
-                if ($isWhatIf) {
-                    Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
-                }
-                else {
-                    try {
-                        Disable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction Stop | Out-Null
-                        Write-Host "Disabled Scheduled Task: $($task.Path)\$($task.Name)"
-                    }
-                    catch {
-                        Write-Host "Failed to disable Scheduled Task: $($task.Path)\$($task.Name) - $($_.Exception.Message)" -ForegroundColor Yellow
-                    }
-                }
-            }
-            else {
-                Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) is already disabled."
-            }
-        }
-        else {
-            Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) not found."
-        }
-    }
-    Write-Host ""
-}
-
-function Enable-TelemetryScheduledTasks {
-    $tasks = @(
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "Microsoft Compatibility Appraiser Exp" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "ProgramDataUpdater" },
-        @{ Path = "\Microsoft\Windows\Application Experience"; Name = "StartupAppTask" },
-        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "Consolidator" },
-        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program"; Name = "UsbCeip" },
-        @{ Path = "\Microsoft\Windows\DiskDiagnostic"; Name = "Microsoft-Windows-DiskDiagnosticDataCollector" },
-        @{ Path = "\Microsoft\Windows\Autochk"; Name = "Proxy" }
-    )
-
-    Write-Host "> Enabling telemetry scheduled tasks..."
-    $isWhatIf = $WhatIfPreference -or ($null -ne $script:Params -and $script:Params.ContainsKey("WhatIf"))
-    foreach ($task in $tasks) {
-        $taskObj = Get-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction SilentlyContinue
-        if ($taskObj) {
-            if ($taskObj.State -eq 'Disabled') {
-                if ($isWhatIf) {
-                    Write-Host "[WhatIf] Enable Scheduled Task: $($task.Path)\$($task.Name)" -ForegroundColor Cyan
-                }
-                else {
-                    try {
-                        Enable-ScheduledTask -TaskPath $task.Path -TaskName $task.Name -ErrorAction Stop | Out-Null
-                        Write-Host "Enabled Scheduled Task: $($task.Path)\$($task.Name)"
-                    }
-                    catch {
-                        Write-Host "Failed to enable Scheduled Task: $($task.Path)\$($task.Name) - $($_.Exception.Message)" -ForegroundColor Yellow
-                    }
-                }
-            }
-            else {
-                Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) is already enabled."
-            }
-        }
-        else {
-            Write-Verbose "Scheduled Task $($task.Path)\$($task.Name) not found."
-        }
-    }
-    Write-Host ""
 }

--- a/Scripts/Features/TelemetryScheduledTasks.ps1
+++ b/Scripts/Features/TelemetryScheduledTasks.ps1
@@ -1,0 +1,128 @@
+# List of known Windows telemetry-related scheduled tasks
+<#
+    .SYNOPSIS
+    Returns the list of known Windows telemetry-related scheduled tasks.
+
+    .DESCRIPTION
+    Returns an array of hashtables, each with a Path and Name key, representing
+    scheduled tasks that collect or report telemetry data on Windows.
+
+    .EXAMPLE
+    Get-TelemetryScheduledTasks
+#>
+function Get-TelemetryScheduledTasks {
+    return @(
+        @{ Path = "\Microsoft\Windows\Application Experience\"; Name = "Microsoft Compatibility Appraiser" },
+        @{ Path = "\Microsoft\Windows\Application Experience\"; Name = "Microsoft Compatibility Appraiser Exp" },
+        @{ Path = "\Microsoft\Windows\Application Experience\"; Name = "ProgramDataUpdater" },
+        @{ Path = "\Microsoft\Windows\Application Experience\"; Name = "StartupAppTask" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program\"; Name = "Consolidator" },
+        @{ Path = "\Microsoft\Windows\Customer Experience Improvement Program\"; Name = "UsbCeip" },
+        @{ Path = "\Microsoft\Windows\DiskDiagnostic\"; Name = "Microsoft-Windows-DiskDiagnosticDataCollector" },
+        @{ Path = "\Microsoft\Windows\Autochk\"; Name = "Proxy" }
+    )
+}
+
+<#
+    .SYNOPSIS
+    Disables known Windows telemetry-related scheduled tasks.
+
+    .DESCRIPTION
+    Iterates over a predefined list of Windows scheduled tasks associated with
+    telemetry and disables each one that exists and is not already disabled.
+    Supports -WhatIf to preview changes without applying them.
+
+    .EXAMPLE
+    Disable-TelemetryScheduledTasks
+#>
+function Disable-TelemetryScheduledTasks {
+    Write-Host "> Disabling telemetry scheduled tasks..."
+    $tasks = Get-TelemetryScheduledTasks
+
+    foreach ($task in $tasks) {
+        if ($script:Params.ContainsKey("WhatIf")) {
+            Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)$($task.Name)" -ForegroundColor Cyan
+            continue
+        }
+
+        $result = Invoke-NonBlocking -ScriptBlock {
+            param($path, $name)
+            Import-Module ScheduledTasks -ErrorAction SilentlyContinue
+            $taskObj = Get-ScheduledTask -TaskPath $path -TaskName $name -ErrorAction SilentlyContinue
+            if (-not $taskObj) {
+                return @{ Success = $true; Status = 'NotFound' }
+            }
+            if ($taskObj.State -ne 'Disabled') {
+                try {
+                    Disable-ScheduledTask -TaskPath $path -TaskName $name -ErrorAction Stop | Out-Null
+                    return @{ Success = $true; Status = 'Disabled' }
+                }
+                catch {
+                    return @{ Success = $false; Status = 'Error'; Error = $_.Exception.Message }
+                }
+            }
+            return @{ Success = $true; Status = 'AlreadyDisabled' }
+        } -ArgumentList @($task.Path, $task.Name)
+
+        switch ($result.Status) {
+            'Disabled'        { Write-Host "Disabled Scheduled Task: $($task.Path)$($task.Name)" }
+            'AlreadyDisabled' { Write-Host "Scheduled Task $($task.Path)$($task.Name) is already disabled" -ForegroundColor DarkGray }
+            'NotFound'        { Write-Host "Scheduled Task $($task.Path)$($task.Name) not found" -ForegroundColor DarkGray }
+            'Error'           { Write-Host "Failed to disable Scheduled Task: $($task.Path)$($task.Name) - $($result.Error)" -ForegroundColor Yellow }
+        }
+    }
+
+    Write-Host ""
+}
+
+<#
+    .SYNOPSIS
+    Enables known Windows telemetry-related scheduled tasks.
+
+    .DESCRIPTION
+    Iterates over a predefined list of Windows scheduled tasks associated with
+    telemetry and enables each one that exists and is currently disabled.
+    Supports -WhatIf to preview changes without applying them.
+
+    .EXAMPLE
+    Enable-TelemetryScheduledTasks
+#>
+function Enable-TelemetryScheduledTasks {
+    Write-Host "> Enabling telemetry scheduled tasks..."
+    $tasks = Get-TelemetryScheduledTasks
+
+    foreach ($task in $tasks) {
+        if ($script:Params.ContainsKey("WhatIf")) {
+            Write-Host "[WhatIf] Enable Scheduled Task: $($task.Path)$($task.Name)" -ForegroundColor Cyan
+            continue
+        }
+
+        $result = Invoke-NonBlocking -ScriptBlock {
+            param($path, $name)
+            Import-Module ScheduledTasks -ErrorAction SilentlyContinue
+            $taskObj = Get-ScheduledTask -TaskPath $path -TaskName $name -ErrorAction SilentlyContinue
+            if (-not $taskObj) {
+                return @{ Success = $true; Status = 'NotFound' }
+            }
+            if ($taskObj.State -eq 'Disabled') {
+                try {
+                    Enable-ScheduledTask -TaskPath $path -TaskName $name -ErrorAction Stop | Out-Null
+                    return @{ Success = $true; Status = 'Enabled' }
+                }
+                catch {
+                    return @{ Success = $false; Status = 'Error'; Error = $_.Exception.Message }
+                }
+            }
+            return @{ Success = $true; Status = 'AlreadyEnabled' }
+        } -ArgumentList @($task.Path, $task.Name)
+
+        switch ($result.Status) {
+            'Enabled'        { Write-Host "Enabled Scheduled Task: $($task.Path)$($task.Name)" }
+            'AlreadyEnabled' { Write-Host "Scheduled Task $($task.Path)$($task.Name) is already enabled." -ForegroundColor DarkGray }
+            'NotFound'       { Write-Host "Scheduled Task $($task.Path)$($task.Name) not found." -ForegroundColor DarkGray }
+            'Error'          { Write-Host "Failed to enable Scheduled Task: $($task.Path)$($task.Name) - $($result.Error)" -ForegroundColor Yellow }
+        }
+    }
+
+    Write-Host ""
+}

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -301,6 +301,7 @@ if (-not $script:WingetInstalled -and -not $Silent) {
 . "$PSScriptRoot/Scripts/Features/RestoreRegistryApplyState.ps1"
 . "$PSScriptRoot/Scripts/Features/RestoreRegistryBackup.ps1"
 . "$PSScriptRoot/Scripts/Features/DisableStoreSearchSuggestions.ps1"
+. "$PSScriptRoot/Scripts/Features/TelemetryScheduledTasks.ps1"
 . "$PSScriptRoot/Scripts/Features/WindowsOptionalFeatures.ps1"
 . "$PSScriptRoot/Scripts/Features/ImportRegistryFile.ps1"
 . "$PSScriptRoot/Scripts/Features/ReplaceStartMenu.ps1"


### PR DESCRIPTION
Resolves #614

### Changes
- Added a Disable-TelemetryScheduledTasks helper to programmatically locate and disable Microsoft telemetry-related scheduled tasks.
- Hooked this function to run when the DisableTelemetry parameter is processed.
- Supports -WhatIf dry-run previews for scheduled tasks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added telemetry scheduled-task debloating via the `DisableTelemetry` feature flag, wired through `ExecuteParameter` to call `Disable-TelemetryScheduledTasks`.
  * Introduced `Scripts/Features/TelemetryScheduledTasks.ps1` with:
    * `Get-TelemetryScheduledTasks` (returns the telemetry task identifiers to target)
    * `Disable-TelemetryScheduledTasks` (disables tasks; supports `-WhatIf` dry-run previews)
    * `Enable-TelemetryScheduledTasks` (re-enables tasks on undo)
  * Implemented per-task status output (`Disabled`/`Enabled`, `AlreadyDisabled`/`AlreadyEnabled`, `NotFound`, `Error`) and exception messaging when operations fail.
  * Dot-sourced the new telemetry scheduled-task module from `Win11Debloat.ps1` during function import initialization.

  * **Telemetry tasks targeted (7)**
    * **Microsoft Compatibility Appraiser** — collects compatibility/upgrade telemetry for Windows assessment.
    * **ProgramDataUpdater** — collects program inventory data for compatibility/assistant scenarios.
    * **StartupAppTask** — reports startup performance/config telemetry (disables reporting only).
    * **Consolidator (CEIP)** — collects/uploads usage telemetry for CEIP participation.
    * **UsbCeip** — collects USB usage telemetry for device compatibility improvements.
    * **Microsoft-Windows-DiskDiagnosticDataCollector** — collects disk diagnostics (alerts/notifications continue to function).
    * **Autochk Proxy** — collects boot-time disk check metrics (disables telemetry upload only).

* **Bug Fixes / Improvements**
  * Improved undo/rollback for telemetry scheduled-task changes:
    * `Invoke-UndoFeatureAction` now restores telemetry tasks by calling `Enable-TelemetryScheduledTasks` for `DisableTelemetry`.
    * `ExecuteAllChanges` undo flow was adjusted to always invoke `Invoke-UndoFeatureAction -FeatureId $featureId` even when no `RegistryUndoKey` exists (previously branched incorrectly based on registry undo presence).
  * Updated `Config/Features.json` user-facing labels for the `DisableTelemetry` feature and its undo text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->