### PR TITLE
fix(appx): expose swallowed exceptions during Appx Package uninstallation via Write-Verbose

### DIFF
--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -124,6 +124,7 @@ function RemoveApps {
             }
         }
         catch {
+            Write-Verbose "Something went wrong while trying to remove $app: $_"
             if ($DebugPreference -ne "SilentlyContinue") {
                 Write-Host "Something went wrong while trying to remove $app" -ForegroundColor Yellow
                 Write-Host $psitem.Exception.StackTrace -ForegroundColor Gray

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -124,11 +124,7 @@ function RemoveApps {
             }
         }
         catch {
-            Write-Verbose "Something went wrong while trying to remove $app: $_"
-            if ($DebugPreference -ne "SilentlyContinue") {
-                Write-Host "Something went wrong while trying to remove $app" -ForegroundColor Yellow
-                Write-Host $psitem.Exception.StackTrace -ForegroundColor Gray
-            }
+            Write-Verbose "Something went wrong while trying to remove $($app): $_"
         }
     }
 


### PR DESCRIPTION
Resolves #616

### Changes
- Adds a Write-Verbose call inside the catch block of RemoveApps to output the exact exception details.