### PR TITLE
fix(appx): pre-fetch installed packages to prevent redundant uninstallation logs

### DIFF
--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -37,6 +37,44 @@ function RemoveApps {
     # Determine target from script-level params, defaulting to AllUsers
     $targetUser = GetTargetUserForAppRemoval
 
+    # Pre-fetch installed and provisioned packages to optimize performance
+    $installedApps = @()
+    $provisionedApps = @()
+    $querySuccess = $false
+
+    $packagesInfo = Invoke-NonBlocking -ScriptBlock {
+        param($target, $user)
+        $inst = @()
+        $prov = @()
+        $success = $false
+        try {
+            switch ($target) {
+                "AllUsers" {
+                    $inst = @(Get-AppxPackage -AllUsers -ErrorAction Stop | Select-Object -ExpandProperty Name)
+                    $prov = @(Get-AppxProvisionedPackage -Online -ErrorAction Stop | Select-Object -ExpandProperty PackageName)
+                }
+                "CurrentUser" {
+                    $inst = @(Get-AppxPackage -ErrorAction Stop | Select-Object -ExpandProperty Name)
+                }
+                default {
+                    $userAccount = New-Object System.Security.Principal.NTAccount($user)
+                    $userSid = $userAccount.Translate([System.Security.Principal.SecurityIdentifier]).Value
+                    $inst = @(Get-AppxPackage -User $userSid -ErrorAction Stop | Select-Object -ExpandProperty Name)
+                }
+            }
+            $success = $true
+        } catch {
+            Write-Verbose "Appx package pre-fetch query failed: $_"
+        }
+        return [PSCustomObject]@{ Installed = $inst; Provisioned = $prov; Success = $success }
+    } -ArgumentList @($targetUser, $targetUser)
+
+    if ($packagesInfo) {
+        $installedApps = @($packagesInfo.Installed)
+        $provisionedApps = @($packagesInfo.Provisioned)
+        $querySuccess = [bool]$packagesInfo.Success
+    }
+
     $appIndex = 0
     $appCount = @($appsList).Count
     $edgeIds = @('Microsoft.Edge', 'XPFFTQ037JWMHS')
@@ -53,6 +91,24 @@ function RemoveApps {
         # Update step name and sub-progress to show which app is being removed (only for bulk removal)
         if ($script:ApplySubStepCallback -and $appCount -gt 1) {
             & $script:ApplySubStepCallback "Removing apps... ($appIndex/$appCount)" $appIndex $appCount
+        }
+
+        # Check if the app is installed or provisioned (only if pre-fetch succeeded)
+        $isInstalled = $true
+        if ($querySuccess) {
+            if (($app -eq "Microsoft.OneDrive") -or ($edgeIds -contains $app)) {
+                $isInstalled = $true
+            } else {
+                $isInstalled = [bool]($installedApps | Where-Object { $_ -like "*$app*" })
+                if (-not $isInstalled -and $targetUser -eq "AllUsers") {
+                    $isInstalled = [bool]($provisionedApps | Where-Object { $_ -like "*$app*" })
+                }
+            }
+        }
+
+        if (-not $isInstalled) {
+            Write-Verbose "App $app is already uninstalled, skipping."
+            continue
         }
 
         Write-Host "Removing $app"


### PR DESCRIPTION
Resolves #627

### Changes
- Pre-fetches installed and provisioned Appx packages in a single batch to optimize performance.
- Checks if the target app package is present in the cache before logging or initiating uninstallation.
- Skips already-uninstalled packages to keep console logs clean and accurate.
- Gracefully degrades by executing normal uninstallation steps if the pre-fetch query fails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

The `RemoveApps` function now pre-fetches the complete set of installed and (for `AllUsers`) provisioned Appx packages at the start of the removal process using a non-blocking `Invoke-NonBlocking` call. The pre-fetch is wrapped in try/catch and stores results in `$installedApps`, `$provisionedApps`, along with a `$querySuccess` flag.

During the per-app loop, removal is gated by this cache. When `$querySuccess` is true, each requested app is checked against the pre-fetched lists to determine whether it is already uninstalled—skipping the WinGet/`Remove-AppxPackage` logic (and its associated console “Removing <AppId>” output) for apps that are not present. For `AllUsers`, the script additionally consults `$provisionedApps` when the app is not found in installed packages. Presence detection includes special-casing for `Microsoft.OneDrive` and Microsoft Edge identifiers to preserve existing removal behavior for those apps.

Graceful degradation is included: if the pre-fetch query fails due to registry/service errors (`$querySuccess` remains false), the script falls back to the existing uninstallation flow rather than silently skipping packages.

**Lines changed:** +56/-0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->