### PR TITLE
Fix: Respect Feature min/max version for comboboxes

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1082,8 +1082,8 @@
       "Category": "Taskbar",
       "RegistryKey": "Combine_Taskbar_Always.reg",
       "ApplyText": "Setting the taskbar on the main display to always combine buttons and hide labels",
-      "UndoLabel": "Use default taskbar combine behavior",
-      "ApplyUndoText": "Resetting the taskbar on the main display to always combine buttons and hide labels",
+      "UndoLabel": null,
+      "ApplyUndoText": null,
       "RegistryUndoKey": null,
       "MinVersion": 22000,
       "MaxVersion": null
@@ -1094,8 +1094,8 @@
       "Category": "Taskbar",
       "RegistryKey": "Combine_MMTaskbar_Always.reg",
       "ApplyText": "Setting the taskbar on secondary displays to always combine buttons and hide labels",
-      "UndoLabel": "Use default taskbar combine behavior",
-      "ApplyUndoText": "Resetting the taskbar on secondary displays to always combine buttons and hide labels",
+      "UndoLabel": null,
+      "ApplyUndoText": null,
       "RegistryUndoKey": null,
       "MinVersion": 22000,
       "MaxVersion": null

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -275,7 +275,12 @@ function Build-DynamicTweaks {
 
                 # When only 1 value remains, render as the underlying feature directly
                 if ($filteredValues.Count -eq 1) {
-                    $soleFid = $filteredValues[0].FeatureIds[0]
+                    $featureIds = $filteredValues[0].FeatureIds
+
+                    if (-not $featureIds -or $featureIds.Count -eq 0) { continue }
+                    
+                    $soleFid = $featureIds[0]
+
                     if ($featureMap.ContainsKey($soleFid)) {
                         $soleFeature = $featureMap[$soleFid]
                         $opt = 'Apply'

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -192,6 +192,12 @@ function Build-DynamicTweaks {
         }
     }
 
+    # Build a FeatureId -> feature lookup for version filtering in groups
+    $featureMap = @{}
+    foreach ($f in $featuresJson.Features) {
+        $featureMap[$f.FeatureId] = $f
+    }
+
     foreach ($categoryObj in $orderedCategories) {
         $categoryName = $categoryObj.Name
 
@@ -250,7 +256,55 @@ function Build-DynamicTweaks {
         foreach ($item in $sortedItems) {
             if ($item.Type -eq 'group') {
                 $group = $item.Data
-                $items = @('No Change') + ($group.Values | ForEach-Object { $_.Label })
+                # Filter values by Windows version compatibility of their referenced features
+                $filteredValues = @($group.Values | Where-Object {
+                    $allCompatible = $true
+                    foreach ($fid in $_.FeatureIds) {
+                        if ($featureMap.ContainsKey($fid)) {
+                            $f = $featureMap[$fid]
+                            if (($f.MinVersion -and $WinVersion -lt $f.MinVersion) -or ($f.MaxVersion -and $WinVersion -gt $f.MaxVersion)) {
+                                $allCompatible = $false
+                                break
+                            }
+                        }
+                    }
+                    $allCompatible
+                })
+                # Skip the group entirely if all values are incompatible with this Windows version
+                if ($filteredValues.Count -eq 0) { continue }
+
+                # When only 1 value remains, render as the underlying feature directly
+                if ($filteredValues.Count -eq 1) {
+                    $soleFid = $filteredValues[0].FeatureIds[0]
+                    if ($featureMap.ContainsKey($soleFid)) {
+                        $soleFeature = $featureMap[$soleFid]
+                        $opt = 'Apply'
+                        if ($soleFeature.FeatureId -match '^Disable') { $opt = 'Disable' } elseif ($soleFeature.FeatureId -match '^Enable') { $opt = 'Enable' }
+                        $items = @('No Change', $opt)
+                        $comboName = ("Feature_{0}_Combo" -f $soleFeature.FeatureId) -replace '[^a-zA-Z0-9_]', ''
+                        $combo = CreateLabeledCombo -parent $panel -labelText $soleFeature.Label -comboName $comboName -items $items
+                        # attach tooltip from Features.json if present
+                        if ($soleFeature.ToolTip -or $soleFeature.DisableWhenApplied -eq $true) {
+                            $tooltipText = $soleFeature.ToolTip
+                            if ($soleFeature.DisableWhenApplied -eq $true) {
+                                $tooltipText = "This tweak is already applied and cannot be undone automatically. Visit the Win11Debloat wiki for instructions on how to manually revert this change."
+                            }
+                            $tipBlock = New-Object System.Windows.Controls.TextBlock
+                            $tipBlock.Text = $tooltipText
+                            $tipBlock.TextWrapping = 'Wrap'
+                            $tipBlock.MaxWidth = 420
+                            $combo.ToolTip = $tipBlock
+                            [System.Windows.Controls.ToolTipService]::SetShowOnDisabled($combo, $true)
+                            $lblBorderObj = $null
+                            try { $lblBorderObj = $Window.FindName("$comboName`_LabelBorder") } catch {}
+                            if ($lblBorderObj) { $lblBorderObj.ToolTip = $tipBlock }
+                        }
+                        $script:UiControlMappings[$comboName] = @{ Type = 'feature'; FeatureId = $soleFeature.FeatureId; Label = $soleFeature.Label; Category = $categoryName }
+                    }
+                    continue
+                }
+
+                $items = @('No Change') + ($filteredValues | ForEach-Object { $_.Label })
                 $comboName = 'Group_{0}Combo' -f $group.GroupId
                 $combo = CreateLabeledCombo -parent $panel -labelText $group.Label -comboName $comboName -items $items
                 # attach tooltip from UiGroups if present
@@ -264,7 +318,7 @@ function Build-DynamicTweaks {
                     try { $lblBorderObj = $Window.FindName("$comboName`_LabelBorder") } catch {}
                     if ($lblBorderObj) { $lblBorderObj.ToolTip = $tipBlock }
                 }
-                $script:UiControlMappings[$comboName] = @{ Type = 'group'; Values = $group.Values; Label = $group.Label; Category = $categoryName }
+                $script:UiControlMappings[$comboName] = @{ Type = 'group'; Values = $filteredValues; Label = $group.Label; Category = $categoryName }
             }
             elseif ($item.Type -eq 'feature') {
                 $feature = $item.Data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed undo labels/text from the taskbar “always combine” options to reduce unnecessary UI clutter.

* **Improvements**
  * The tweaks interface now hides incompatible feature options based on your Windows version.
  * When only one compatible option exists within a group, it’s shown directly for a cleaner, more accurate selection experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->