### PR TITLE
Fix store suggestions not getting disabled correctly for all users when running as other user

### DIFF
--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -125,7 +125,8 @@ function ExecuteParameter {
             }
 
             Write-Host "> Disabling Microsoft Store search suggestions for user $(GetUserName)..."
-            DisableStoreSearchSuggestions
+            $storeDb = GetStoreAppsDatabasePathForUser -UserName (GetUserName)
+            DisableStoreSearchSuggestions -StoreAppsDatabase $storeDb
             Write-Host ""
             return
         }
@@ -289,7 +290,8 @@ function Invoke-UndoFeatureAction {
             }
 
             Write-Host "> Re-enabling Microsoft Store search suggestions for user $(GetUserName)..."
-            EnableStoreSearchSuggestions
+            $storeDb = GetStoreAppsDatabasePathForUser -UserName (GetUserName)
+            EnableStoreSearchSuggestions -StoreAppsDatabase $storeDb
             Write-Host ""
             return
         }

--- a/Scripts/Features/ExecuteChanges.ps1
+++ b/Scripts/Features/ExecuteChanges.ps1
@@ -126,7 +126,9 @@ function ExecuteParameter {
 
             Write-Host "> Disabling Microsoft Store search suggestions for user $(GetUserName)..."
             $storeDb = GetStoreAppsDatabasePathForUser -UserName (GetUserName)
-            DisableStoreSearchSuggestions -StoreAppsDatabase $storeDb
+            if ($storeDb) {
+                DisableStoreSearchSuggestions -StoreAppsDatabase $storeDb
+            }
             Write-Host ""
             return
         }
@@ -291,7 +293,9 @@ function Invoke-UndoFeatureAction {
 
             Write-Host "> Re-enabling Microsoft Store search suggestions for user $(GetUserName)..."
             $storeDb = GetStoreAppsDatabasePathForUser -UserName (GetUserName)
-            EnableStoreSearchSuggestions -StoreAppsDatabase $storeDb
+            if ($storeDb) {
+                EnableStoreSearchSuggestions -StoreAppsDatabase $storeDb
+            }
             Write-Host ""
             return
         }

--- a/Scripts/Features/GetCurrentTweakState.ps1
+++ b/Scripts/Features/GetCurrentTweakState.ps1
@@ -50,10 +50,7 @@ function Test-FeatureApplied {
                 return (Test-StoreSearchSuggestionsDisabledForAllUsers)
             }
 
-            $storeDbPath = "$env:LocalAppData\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
-            if ($script:Params.ContainsKey('User')) {
-                $storeDbPath = GetUserDirectory -userName "$(GetUserName)" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
-            }
+            $storeDbPath = GetStoreAppsDatabasePathForUser -UserName (GetUserName)
 
             return (Test-StoreSearchSuggestionsDisabled -StoreAppsDatabase $storeDbPath)
         }

--- a/Scripts/Features/StoreSearchSuggestions.ps1
+++ b/Scripts/Features/StoreSearchSuggestions.ps1
@@ -1,4 +1,16 @@
-# Disables Microsoft Store search suggestions in the start menu for all users by denying access to the Store app database file for each user
+<#
+    .SYNOPSIS
+    Disables Microsoft Store search suggestions in the start menu for all user profiles.
+
+    .DESCRIPTION
+    Iterates over every existing user profile and the Default user profile,
+    denying the EVERYONE group FullControl access to each user's Store app
+    database file (store.db). This prevents Windows from showing Store search
+    suggestions in the start menu search pane.
+
+    .EXAMPLE
+    DisableStoreSearchSuggestionsForAllUsers
+#>
 function DisableStoreSearchSuggestionsForAllUsers {
     # Get path to Store app database for all users
     $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages"
@@ -15,7 +27,22 @@ function DisableStoreSearchSuggestionsForAllUsers {
 }
 
 
-# Disables Microsoft Store search suggestions in the start menu by denying access to the Store app database file
+<#
+    .SYNOPSIS
+    Disables Microsoft Store search suggestions for a single user.
+
+    .DESCRIPTION
+    Denies the EVERYONE group FullControl access to the specified Store app
+    database file (store.db). If the file does not exist (e.g. on EEA systems
+    where Store app suggestions are absent by default), it creates the file
+    and its parent directory first to prevent Windows from recreating it later.
+
+    .PARAMETER StoreAppsDatabase
+    The full path to the user's store.db file.
+
+    .EXAMPLE
+    DisableStoreSearchSuggestions -StoreAppsDatabase "C:\Users\Jeff\AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+#>
 function DisableStoreSearchSuggestions {
     param (
         [Parameter(Mandatory)]
@@ -48,6 +75,19 @@ function DisableStoreSearchSuggestions {
     Write-Host "Disabled Microsoft Store search suggestions for user $userName"
 }
 
+<#
+    .SYNOPSIS
+    Re-enables Microsoft Store search suggestions in the start menu for all user profiles.
+
+    .DESCRIPTION
+    Iterates over every existing user profile and the Default user profile,
+    removing the deny ACL from each user's Store app database file (store.db)
+    and then deleting the file. This restores the default Windows behavior
+    where Store search suggestions appear in the start menu.
+
+    .EXAMPLE
+    EnableStoreSearchSuggestionsForAllUsers
+#>
 function EnableStoreSearchSuggestionsForAllUsers {
     # Get path to Store app database for all users
     $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages"
@@ -63,6 +103,22 @@ function EnableStoreSearchSuggestionsForAllUsers {
     EnableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
 }
 
+<#
+    .SYNOPSIS
+    Re-enables Microsoft Store search suggestions for a single user.
+
+    .DESCRIPTION
+    Takes ownership of the specified Store app database file, removes any
+    EVERYONE deny FullControl ACL entries, and deletes the file. If the file
+    does not exist, no action is taken. Callers should handle the case where
+    the file is absent gracefully.
+
+    .PARAMETER StoreAppsDatabase
+    The full path to the user's store.db file.
+
+    .EXAMPLE
+    EnableStoreSearchSuggestions -StoreAppsDatabase "C:\Users\Jeff\AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+#>
 function EnableStoreSearchSuggestions {
     param (
         [Parameter(Mandatory)]
@@ -113,6 +169,24 @@ function EnableStoreSearchSuggestions {
     }
 }
 
+<#
+    .SYNOPSIS
+    Returns the full path to the Store app database file for a given user.
+
+    .DESCRIPTION
+    Resolves the path to the Microsoft Store app database (store.db) for the
+    specified username. When no username is provided or the value is empty,
+    falls back to the current user's local app data path via $env:LOCALAPPDATA.
+
+    .PARAMETER UserName
+    The target username. Pass an empty string or omit to resolve for the current user.
+
+    .EXAMPLE
+    GetStoreAppsDatabasePathForUser -UserName "Jeff"
+
+    .EXAMPLE
+    GetStoreAppsDatabasePathForUser -UserName "Default"
+#>
 function GetStoreAppsDatabasePathForUser {
     param(
         [string]$UserName
@@ -125,6 +199,21 @@ function GetStoreAppsDatabasePathForUser {
     return (GetUserDirectory -userName $UserName -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false)
 }
 
+<#
+    .SYNOPSIS
+    Tests whether Store search suggestions are disabled for a single user.
+
+    .DESCRIPTION
+    Checks whether the specified store.db file has an EVERYONE deny
+    FullControl ACL entry applied. Returns $true if the deny rule is present,
+    $false otherwise (including when the file or directory does not exist).
+
+    .PARAMETER StoreAppsDatabase
+    The full path to the user's store.db file.
+
+    .EXAMPLE
+    Test-StoreSearchSuggestionsDisabled -StoreAppsDatabase "C:\Users\Jeff\AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+#>
 function Test-StoreSearchSuggestionsDisabled {
     param(
         [Parameter(Mandatory)]
@@ -162,6 +251,19 @@ function Test-StoreSearchSuggestionsDisabled {
     return $false
 }
 
+<#
+    .SYNOPSIS
+    Tests whether Store search suggestions are disabled for all user profiles.
+
+    .DESCRIPTION
+    Collects the store.db paths for all existing user profiles and the Default
+    user profile, then verifies that every one of them has the EVERYONE deny
+    FullControl ACL applied. Returns $true only if ALL paths pass the check.
+    Returns $false immediately if any user's store.db is not disabled.
+
+    .EXAMPLE
+    Test-StoreSearchSuggestionsDisabledForAllUsers
+#>
 function Test-StoreSearchSuggestionsDisabledForAllUsers {
     $paths = @()
 

--- a/Scripts/Features/StoreSearchSuggestions.ps1
+++ b/Scripts/Features/StoreSearchSuggestions.ps1
@@ -41,7 +41,7 @@ function DisableStoreSearchSuggestionsForAllUsers {
     The full path to the user's store.db file.
 
     .EXAMPLE
-    DisableStoreSearchSuggestions -StoreAppsDatabase "C:\Users\Jeff\AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+    DisableStoreSearchSuggestions -StoreAppsDatabase "$env:LOCALAPPDATA\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
 #>
 function DisableStoreSearchSuggestions {
     param (
@@ -117,7 +117,7 @@ function EnableStoreSearchSuggestionsForAllUsers {
     The full path to the user's store.db file.
 
     .EXAMPLE
-    EnableStoreSearchSuggestions -StoreAppsDatabase "C:\Users\Jeff\AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+    EnableStoreSearchSuggestions -StoreAppsDatabase "$env:LOCALAPPDATA\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
 #>
 function EnableStoreSearchSuggestions {
     param (

--- a/Scripts/Features/StoreSearchSuggestions.ps1
+++ b/Scripts/Features/StoreSearchSuggestions.ps1
@@ -23,7 +23,9 @@ function DisableStoreSearchSuggestionsForAllUsers {
 
     # Also disable start search suggestions for the default user profile
     $defaultStoreDbPath = GetStoreAppsDatabasePathForUser -UserName "Default"
-    DisableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
+    if ($defaultStoreDbPath) {
+        DisableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
+    }
 }
 
 
@@ -100,7 +102,9 @@ function EnableStoreSearchSuggestionsForAllUsers {
 
     # Also re-enable for the default user profile
     $defaultStoreDbPath = GetStoreAppsDatabasePathForUser -UserName "Default"
-    EnableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
+    if ($defaultStoreDbPath) {
+        EnableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
+    }
 }
 
 <#

--- a/Scripts/Features/StoreSearchSuggestions.ps1
+++ b/Scripts/Features/StoreSearchSuggestions.ps1
@@ -5,28 +5,25 @@ function DisableStoreSearchSuggestionsForAllUsers {
     $usersStoreDbPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
 
     # Go through all users and disable start search suggestions
-    ForEach ($storeDbPath in $usersStoreDbPaths) {
-        DisableStoreSearchSuggestions ($storeDbPath.FullName + "\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db")
+    foreach ($storeDbPath in $usersStoreDbPaths) {
+        DisableStoreSearchSuggestions -StoreAppsDatabase ($storeDbPath.FullName + "\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db")
     }
 
     # Also disable start search suggestions for the default user profile
-    $defaultStoreDbPath = GetUserDirectory -userName "Default" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
-    DisableStoreSearchSuggestions $defaultStoreDbPath
+    $defaultStoreDbPath = GetStoreAppsDatabasePathForUser -UserName "Default"
+    DisableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
 }
 
 
 # Disables Microsoft Store search suggestions in the start menu by denying access to the Store app database file
 function DisableStoreSearchSuggestions {
     param (
-        $StoreAppsDatabase = "$env:LocalAppData\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+        [Parameter(Mandatory)]
+        [string]$StoreAppsDatabase
     )
 
-    # Change path to correct user if a user was specified
-    if ($script:Params.ContainsKey("User")) {
-        $StoreAppsDatabase = GetUserDirectory -userName "$(GetUserName)" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
-    }
-
     $userName = [regex]::Match($StoreAppsDatabase, '(?:Users\\)([^\\]+)(?:\\AppData)').Groups[1].Value
+    if (-not $userName) { $userName = '<unknown>' }
 
     # This file doesn't exist in EEA (No Store app suggestions).
     if (-not (Test-Path -Path $StoreAppsDatabase))
@@ -57,24 +54,20 @@ function EnableStoreSearchSuggestionsForAllUsers {
     $usersStoreDbPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
 
     # Go through all users and re-enable start search suggestions
-    ForEach ($storeDbPath in $usersStoreDbPaths) {
-        EnableStoreSearchSuggestions ($storeDbPath.FullName + "\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db")
+    foreach ($storeDbPath in $usersStoreDbPaths) {
+        EnableStoreSearchSuggestions -StoreAppsDatabase ($storeDbPath.FullName + "\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db")
     }
 
     # Also re-enable for the default user profile
-    $defaultStoreDbPath = GetUserDirectory -userName "Default" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
-    EnableStoreSearchSuggestions $defaultStoreDbPath
+    $defaultStoreDbPath = GetStoreAppsDatabasePathForUser -UserName "Default"
+    EnableStoreSearchSuggestions -StoreAppsDatabase $defaultStoreDbPath
 }
 
 function EnableStoreSearchSuggestions {
     param (
-        $StoreAppsDatabase = "$env:LocalAppData\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+        [Parameter(Mandatory)]
+        [string]$StoreAppsDatabase
     )
-
-    # Change path to correct user if a user was specified
-    if ($script:Params.ContainsKey("User")) {
-        $StoreAppsDatabase = GetUserDirectory -userName "$(GetUserName)" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
-    }
 
     $userName = [regex]::Match($StoreAppsDatabase, '(?:Users\\)([^\\]+)(?:\\AppData)').Groups[1].Value
     if (-not $userName) { $userName = '<unknown>' }
@@ -118,6 +111,18 @@ function EnableStoreSearchSuggestions {
     catch {
         throw "Failed to remove '$StoreAppsDatabase' while undoing Microsoft Store search suggestions for user $userName. $($_.Exception.Message)"
     }
+}
+
+function GetStoreAppsDatabasePathForUser {
+    param(
+        [string]$UserName
+    )
+
+    if ([string]::IsNullOrWhiteSpace($UserName)) {
+        return "$env:LOCALAPPDATA\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db"
+    }
+
+    return (GetUserDirectory -userName $UserName -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false)
 }
 
 function Test-StoreSearchSuggestionsDisabled {
@@ -166,7 +171,7 @@ function Test-StoreSearchSuggestionsDisabledForAllUsers {
         $paths += ($storeDbPath.FullName + "\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db")
     }
 
-    $defaultStoreDbPath = GetUserDirectory -userName "Default" -fileName "AppData\Local\Packages\Microsoft.WindowsStore_8wekyb3d8bbwe\LocalState\store.db" -exitIfPathNotFound $false
+    $defaultStoreDbPath = GetStoreAppsDatabasePathForUser -UserName "Default"
     if ($defaultStoreDbPath) {
         $paths += $defaultStoreDbPath
     }

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -300,7 +300,7 @@ if (-not $script:WingetInstalled -and -not $Silent) {
 . "$PSScriptRoot/Scripts/Features/RegistryBackupValidation.ps1"
 . "$PSScriptRoot/Scripts/Features/RestoreRegistryApplyState.ps1"
 . "$PSScriptRoot/Scripts/Features/RestoreRegistryBackup.ps1"
-. "$PSScriptRoot/Scripts/Features/DisableStoreSearchSuggestions.ps1"
+. "$PSScriptRoot/Scripts/Features/StoreSearchSuggestions.ps1"
 . "$PSScriptRoot/Scripts/Features/TelemetryScheduledTasks.ps1"
 . "$PSScriptRoot/Scripts/Features/WindowsOptionalFeatures.ps1"
 . "$PSScriptRoot/Scripts/Features/ImportRegistryFile.ps1"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Refactored the Microsoft Store search suggestions feature to correctly target the per-user `store.db` when running under other user contexts, and added full undo/re-enable support.

## Changes

### StoreSearchSuggestions.ps1
- **`DisableStoreSearchSuggestions`**: Now requires a mandatory **`-StoreAppsDatabase`** parameter, removing the previous default-path behavior and any remapping based on `script:Params["User"]`.
- **`DisableStoreSearchSuggestionsForAllUsers`**: Disables Store search suggestions per profile by enumerating per-user `store.db` candidates and calling `DisableStoreSearchSuggestions` with an explicit per-user `store.db` path; resolves the default-user database path via **`GetStoreAppsDatabasePathForUser -UserName "Default"`**.
- **`GetStoreAppsDatabasePathForUser`** (new): Centralizes `store.db` resolution for a specified username; falls back to the current user’s `store.db` under `$env:LOCALAPPDATA` when `UserName` is null/empty.
- **`EnableStoreSearchSuggestions`** (new): Re-enables Store search suggestions for a single user by:
  - returning immediately if `store.db` is missing,
  - taking ownership and updating ACLs (via `takeown`/`icacls`),
  - removing **EVERYONE** deny ACL entries granting **FullControl**,
  - deleting `store.db` to restore default Windows behavior.
- **`EnableStoreSearchSuggestionsForAllUsers`** (new): Enables Store search suggestions across user profiles.
- **`Test-StoreSearchSuggestionsDisabledForAllUsers`**: Updated to gather the default-user `store.db` path using **`GetStoreAppsDatabasePathForUser -UserName "Default"`** and aligned related help text with the ACL “disabled” condition.

### ExecuteChanges.ps1
- When running for a specific user, the script now resolves the target `store.db` via **`GetStoreAppsDatabasePathForUser -UserName (GetUserName)`** and passes it into `DisableStoreSearchSuggestions`, and uses the same per-user database path for the undo/re-enable path.

### GetCurrentTweakState.ps1
- Updated the `'DisableStoreSearchSuggestions'` check in `Test-FeatureApplied` to compute the user-specific `store.db` path using **`GetStoreAppsDatabasePathForUser -UserName (GetUserName)`**, replacing the previous hardcoded default path and conditional override logic.

### Win11Debloat.ps1
- Updated feature module import to load **`StoreSearchSuggestions.ps1`** instead of **`DisableStoreSearchSuggestions.ps1`**, so the refactored logic is used.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->