### PR TITLE
fix(restore): correct sub-key path matching in backup allow-list validation

### DIFF
--- a/Scripts/Features/RegistryBackupValidation.ps1
+++ b/Scripts/Features/RegistryBackupValidation.ps1
@@ -385,7 +385,7 @@ function Find-RegistryAllowListPlanMatch {
             continue
         }
 
-        $subKeyPrefix = "$($plan.NormalizedPath)\\"
+        $subKeyPrefix = "$($plan.NormalizedPath)\"
         if ($NormalizedPath.StartsWith($subKeyPrefix, [System.StringComparison]::OrdinalIgnoreCase)) {
             return [PSCustomObject]@{
                 IsDescendant = $true


### PR DESCRIPTION
Fixes #644

`Find-RegistryAllowListPlanMatch` built the descendant-match prefix with a doubled backslash (`"$($plan.NormalizedPath)\\"`). In a double-quoted PowerShell string that is two literal backslashes, but normalized child paths use a single separator - so the `StartsWith` check never matched a real child, and any backup whose key had sub-keys was rejected as an "unexpected registry path" and could not be restored (fails closed).

### Change
```diff
- $subKeyPrefix = "$($plan.NormalizedPath)\\"
+ $subKeyPrefix = "$($plan.NormalizedPath)\"
```

### Verification (static)
```
$child.StartsWith("$plan\\",'OrdinalIgnoreCase')  -> False  (before)
$child.StartsWith("$plan\", 'OrdinalIgnoreCase')  -> True   (after)
```
File parses clean.

> ?? Static analysis only - not yet run against a live backup/restore on Windows. Runtime confirmation welcome before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed a registry backup restore validation bug by correcting the descendant-path allowlist matching logic in `Find-RegistryAllowListPlanMatch`.

## Changes
- **Scripts/Features/RegistryBackupValidation.ps1**: Updated the subkey prefix construction to use a single backslash separator (`"$($plan.NormalizedPath)\"`) instead of a doubled backslash literal (`"$($plan.NormalizedPath)\\"`).

## Impact
The previous prefix mismatch caused the case-insensitive `StartsWith` validation to fail for legitimate backups that include sub-keys, leading to restore attempts being rejected with an “unexpected registry path” error. With the corrected separator, backups containing sub-keys under `IncludeSubKeys` plans validate properly and restore can proceed as intended.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->