### PR TITLE
fix(app-removal): don't treat AllUsers/CurrentUser as a username at startup

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -423,7 +423,11 @@ if ($script:Params.ContainsKey("User")) {
     GetUserDirectory -userName $script:Params.Item("User") | Out-Null
 }
 if ($script:Params.ContainsKey("AppRemovalTarget")) {
-    GetUserDirectory -userName $script:Params.Item("AppRemovalTarget") | Out-Null
+    $appRemovalTargetValue = $script:Params.Item("AppRemovalTarget")
+    # 'AllUsers' / 'CurrentUser' are sentinel scope values, not real usernames - don't resolve them as a profile
+    if ($appRemovalTargetValue -notin @('AllUsers', 'CurrentUser')) {
+        GetUserDirectory -userName $appRemovalTargetValue | Out-Null
+    }
 }
 
 # Remove LastUsedSettings.json file if it exists and is empty


### PR DESCRIPTION
Fixes #646

`-AppRemovalTarget` accepts the sentinel scope values `AllUsers` and `CurrentUser` (also produced by the config import for `AppRemovalScopeIndex` 0/1), but the startup existence check passed them to `GetUserDirectory`, which tries to resolve a profile, fails, and calls `AwaitKeyToExit` - so the script exits before doing any work.

### Change
```diff
 if ($script:Params.ContainsKey("AppRemovalTarget")) {
-    GetUserDirectory -userName $script:Params.Item("AppRemovalTarget") | Out-Null
+    $appRemovalTargetValue = $script:Params.Item("AppRemovalTarget")
+    # 'AllUsers' / 'CurrentUser' are sentinel scope values, not real usernames
+    if ($appRemovalTargetValue -notin @('AllUsers', 'CurrentUser')) {
+        GetUserDirectory -userName $appRemovalTargetValue | Out-Null
+    }
 }
```
A real username is still validated as before. File parses clean.

> ?? Static analysis only - not yet run on Windows. Runtime confirmation welcome before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

This PR fixes issue `#646`, where using `-AppRemovalTarget` with the sentinel scope values `AllUsers` or `CurrentUser` caused the script to exit at startup before any app removal operations occurred.

### Root Cause

The startup validation code treated `AppRemovalTarget` as a literal username and passed it to `GetUserDirectory` for profile resolution. However, `AllUsers` and `CurrentUser` are sentinel values meant to indicate scope (all user profiles or current user only) rather than actual usernames. Since `GetUserDirectory` could not resolve these sentinel values, the validation failed and triggered script termination via `AwaitKeyToExit`.

These sentinel values could be specified either directly via the CLI parameter `-AppRemovalTarget` or through config file import when `AppRemovalScopeIndex` was set to 0 (AllUsers) or 1 (CurrentUser).

### Changes

The fix adds a conditional check in the startup validation section to skip the `GetUserDirectory` profile lookup when `AppRemovalTarget` contains one of the two sentinel values (`AllUsers` or `CurrentUser`). Real usernames are still validated as before.

Specifically, the code now checks `if ($appRemovalTargetValue -notin @('AllUsers', 'CurrentUser'))` before calling `GetUserDirectory`, preserving existing validation for genuine usernames while preventing premature termination when using the intended scope values.

### Files Modified

- `Win11Debloat.ps1`: +5/-1 lines

<!-- end of auto-generated comment: release notes by coderabbit.ai -->