### PR TITLE
fix(app-removal): block removal of shell/sign-in/runtime-critical packages

### DIFF
--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -43,12 +43,29 @@ function RemoveApps {
     $edgeUninstallSucceeded = $false
     $edgeScheduledTaskAdded = $false
 
+    # Packages that must never be removed: removing them breaks the shell, sign-in, or the app runtime
+    $criticalAppDenylist = @(
+        'ShellExperienceHost', 'StartMenuExperienceHost', 'AAD.BrokerPlugin', 'CloudExperienceHost',
+        'Microsoft.UI.Xaml', 'Microsoft.VCLibs', 'Microsoft.NET.Native', 'Microsoft.WindowsAppRuntime',
+        'DesktopAppInstaller', 'Microsoft.AccountsControl', 'Microsoft.LockApp', 'SecHealthUI'
+    )
+
     Foreach ($app in $appsList) {
         if ($script:CancelRequested) {
             return
         }
 
         $appIndex++
+
+        # Safety guard: never remove packages critical to the shell, sign-in, or app runtimes
+        $isCriticalApp = $false
+        foreach ($criticalApp in $criticalAppDenylist) {
+            if ($app -like "*$criticalApp*") { $isCriticalApp = $true; break }
+        }
+        if ($isCriticalApp) {
+            Write-Host "Skipping '$app': this package is critical to Windows and removal is blocked." -ForegroundColor Yellow
+            continue
+        }
 
         # Update step name and sub-progress to show which app is being removed (only for bulk removal)
         if ($script:ApplySubStepCallback -and $appCount -gt 1) {


### PR DESCRIPTION
Fixes #648

Adds a hard denylist in `RemoveApps` so packages critical to the shell, sign-in, or app runtime are never removed - regardless of how they entered the list. The `-Apps` path validates against `Apps.json`, but `RemoveAppsCustom` reads `CustomAppsList` unchecked and entries are substring-wildcarded, so this is defense-in-depth against bricking the machine.

The denylisted families (`ShellExperienceHost`, `AAD.BrokerPlugin`, `Microsoft.VCLibs`, `Microsoft.WindowsAppRuntime`, `DesktopAppInstaller`, .) do not appear in `Config/Apps.json`, so no legitimate removal is affected.

Static check:
```
'Microsoft.Windows.ShellExperienceHost' -> blocked
'Microsoft.AAD.BrokerPlugin'            -> blocked
'Microsoft.VCLibs.140.00'               -> blocked
'Microsoft.WindowsStore'                -> allowed
'Microsoft.BingNews'                    -> allowed
```
File parses clean.

> ?? Static analysis only - not run on Windows. Runtime confirmation welcome before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## RemoveApps.ps1

Added a `$criticalAppDenylist` hard safety guard in `RemoveApps` to block removal of Windows system-essential app packages. During iteration over `$appsList`, each `$app` is checked against the denylist using a substring wildcard match (`$app -like "*$criticalApp*"`). On a match, `RemoveApps` logs a yellow “Skipping …” message and immediately `continue`s, preventing any existing OneDrive/Edge WinGet (and scheduled-task) uninstall logic and any `Remove-AppxPackage` / `Remove-ProvisionedAppxPackage` removal work from running.

The denylist contains these 12 critical package name fragments:

- `ShellExperienceHost`, `StartMenuExperienceHost`
- `AAD.BrokerPlugin`, `CloudExperienceHost`
- `Microsoft.UI.Xaml`
- `Microsoft.VCLibs`, `Microsoft.NET.Native`, `Microsoft.WindowsAppRuntime`
- `DesktopAppInstaller`
- `Microsoft.AccountsControl`, `Microsoft.LockApp`
- `SecHealthUI`

This protection applies to both `RemoveApps` and the custom-list flow (`RemoveAppsCustom`) because `RemoveAppsCustom` loads entries from `CustomAppsListFilePath` and passes them directly to `RemoveApps`, which performs the same denylist filtering for every entry.

Lines changed: +17/-0
<!-- end of auto-generated comment: release notes by coderabbit.ai -->