### PR TITLE
fix(gui): treat dismissed unsafe-removal confirmation as decline

### DIFF
--- a/Scripts/Helpers/ConfirmUnsafeAppRemoval.ps1
+++ b/Scripts/Helpers/ConfirmUnsafeAppRemoval.ps1
@@ -16,8 +16,6 @@ function ConfirmUnsafeAppRemoval {
     if ($SelectedApps -contains "Microsoft.WindowsStore") {
         $result = Show-MessageBox -Message 'Are you sure that you wish to uninstall the Microsoft Store? This app cannot easily be reinstalled.' -Title 'Are you sure?' -Button 'YesNo' -Icon 'Warning' -Owner $Owner
 
-        # Proceed only on an explicit 'Yes'. Dismissing the dialog (X / Alt+F4 -> $null,
-        # or Escape -> 'Cancel') must decline, not fall through to removal.
         if ($result -ne 'Yes') {
             return $false
         }
@@ -27,8 +25,6 @@ function ConfirmUnsafeAppRemoval {
     if ($SelectedApps -contains "Microsoft.WindowsTerminal") {
         $result = Show-MessageBox -Message 'Are you sure that you wish to remove Windows Terminal? Windows Terminal is the default command-line app for Windows. Ensure you are not running Win11Debloat via Windows Terminal before proceeding to avoid a mid-process failure.' -Title 'Are you sure?' -Button 'YesNo' -Icon 'Warning' -Owner $Owner
 
-        # Proceed only on an explicit 'Yes'. Dismissing the dialog (X / Alt+F4 -> $null,
-        # or Escape -> 'Cancel') must decline, not fall through to removal.
         if ($result -ne 'Yes') {
             return $false
         }

--- a/Scripts/Helpers/ConfirmUnsafeAppRemoval.ps1
+++ b/Scripts/Helpers/ConfirmUnsafeAppRemoval.ps1
@@ -16,7 +16,9 @@ function ConfirmUnsafeAppRemoval {
     if ($SelectedApps -contains "Microsoft.WindowsStore") {
         $result = Show-MessageBox -Message 'Are you sure that you wish to uninstall the Microsoft Store? This app cannot easily be reinstalled.' -Title 'Are you sure?' -Button 'YesNo' -Icon 'Warning' -Owner $Owner
 
-        if ($result -eq 'No') {
+        # Proceed only on an explicit 'Yes'. Dismissing the dialog (X / Alt+F4 -> $null,
+        # or Escape -> 'Cancel') must decline, not fall through to removal.
+        if ($result -ne 'Yes') {
             return $false
         }
     }
@@ -25,7 +27,9 @@ function ConfirmUnsafeAppRemoval {
     if ($SelectedApps -contains "Microsoft.WindowsTerminal") {
         $result = Show-MessageBox -Message 'Are you sure that you wish to remove Windows Terminal? Windows Terminal is the default command-line app for Windows. Ensure you are not running Win11Debloat via Windows Terminal before proceeding to avoid a mid-process failure.' -Title 'Are you sure?' -Button 'YesNo' -Icon 'Warning' -Owner $Owner
 
-        if ($result -eq 'No') {
+        # Proceed only on an explicit 'Yes'. Dismissing the dialog (X / Alt+F4 -> $null,
+        # or Escape -> 'Cancel') must decline, not fall through to removal.
+        if ($result -ne 'Yes') {
             return $false
         }
     }


### PR DESCRIPTION
Fixes #650

`ConfirmUnsafeAppRemoval` blocked only on an exact `'No'`. `Show-MessageBox` returns the window `Tag`, which is `$null` when the dialog is closed via the X button / Alt+F4 (and `'Cancel'` on Escape) - none of which equal `'No'`, so dismissing the confirmation fell through and removed the app. Now proceeds only on an explicit `'Yes'`.

```diff
-        if ($result -eq 'No') {
+        if ($result -ne 'Yes') {
             return $false
         }
```
(both the Store and Windows Terminal guards). File parses clean.

> ?? Static + behavioral verification on Windows 11; GUI dialog not click-tested. Runtime confirmation welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This pull request fixes a logic issue in the `ConfirmUnsafeAppRemoval` function that controls confirmation dialogs for unsafe app removals (Microsoft Store and Windows Terminal).

## Problem
The previous implementation blocked removal only when the user explicitly clicked “No”. However, the `Show-MessageBox` function can return other values when the dialog is dismissed without clicking the buttons:
- `$null` when closed via the window X button or Alt+F4
- `'Cancel'` when dismissed via Escape key  
Since neither equals `'No'`, dismissal could incorrectly allow the app removal to proceed.

## Solution
The guard logic is changed to require an explicit `'Yes'`. After each dialog, the function now cancels unless the result is exactly `'Yes'` (i.e., it returns `$false` when `$result -ne 'Yes'`), so any other dismissal path—including X/Alt+F4/Escape—prevents removal.

Changes: +3 lines, -3 lines
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Test environment:** Windows 11 25H2 (build 26200.8655), Windows PowerShell 5.1.26100.8655, .NET 4.0.30319.42000

The null-on-dismiss (WPF) and the proceed-only-on-Yes guard (PowerShell) are framework-level and build-independent. The GUI dialog was not click-tested.