### PR TITLE
fix(start-menu): don't overwrite the original backup on repeated runs

### DIFF
--- a/Scripts/Features/ReplaceStartMenu.ps1
+++ b/Scripts/Features/ReplaceStartMenu.ps1
@@ -74,8 +74,16 @@ function ReplaceStartMenu {
     $backupBinFile = $startMenuBinFile + ".bak"
 
     if (Test-Path $startMenuBinFile) {
-        # Backup current start menu file
-        Move-Item -Path $startMenuBinFile -Destination $backupBinFile -Force
+        if (Test-Path $backupBinFile) {
+            # A backup already exists from a previous run, so the current start2.bin is the
+            # already-replaced layout, not the user's original. Don't overwrite the original
+            # backup - just remove the current file (the template is copied in below).
+            Remove-Item -Path $startMenuBinFile -Force
+        }
+        else {
+            # Backup the original start menu file (first run only)
+            Move-Item -Path $startMenuBinFile -Destination $backupBinFile -Force
+        }
     }
     else {
         Write-Host "Unable to find original start2.bin file for user $userName, no backup was created for this user" -ForegroundColor Yellow


### PR DESCRIPTION
Fixes #652

`ReplaceStartMenu` backed up the current `start2.bin` to `start2.bin.bak` with `Move-Item -Force` on **every** run. On the second run the current `start2.bin` is the already-replaced layout, so `-Force` overwrote the `.bak` that held the user's **original** layout - losing it permanently and making `RestoreStartMenuFromBackup` restore the cleared layout.

Now the backup is created only when one doesn't already exist; otherwise the current (replaced) file is removed and the original `.bak` is preserved. File parses clean.

> ?? Static analysis only - not run on Windows. Runtime confirmation welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This fix addresses a critical data loss bug in the start menu backup workflow. `ReplaceStartMenu` previously backed up `start2.bin` by moving it to `start2.bin.bak` with `-Force` on every run, allowing a second execution to overwrite the original backup with the already-replaced (cleared/template) layout—so `RestoreStartMenuFromBackup` would restore the wrong data.

The updated `ReplaceStartMenu` preserves the first backup:
- If `start2.bin` exists and `start2.bin.bak` does not, it moves `start2.bin` to `start2.bin.bak` (first run).
- If `start2.bin.bak` already exists, it deletes the current `start2.bin` instead of overwriting the existing backup.

After ensuring the correct backup behavior, the function continues by copying the template `start2.bin` into place as before, preventing repeated runs from permanently destroying the user’s original start menu layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->