### PR TITLE
fix(threading): surface runspace errors instead of swallowing them in GUI mode

### DIFF
--- a/Scripts/Threading/Invoke-NonBlocking.ps1
+++ b/Scripts/Threading/Invoke-NonBlocking.ps1
@@ -45,6 +45,15 @@ function Invoke-NonBlocking {
 
         $result = $ps.EndInvoke($handle)
 
+        # Surface non-terminating errors raised inside the runspace so GUI-mode operations
+        # (e.g. failed app removals) don't fail silently - the runspace keeps its own error
+        # stream that is otherwise discarded on Dispose.
+        if ($ps.HadErrors) {
+            foreach ($runspaceError in $ps.Streams.Error) {
+                Write-Error -ErrorRecord $runspaceError
+            }
+        }
+
         if ($result.Count -eq 0) { return $null }
         if ($result.Count -eq 1) { return $result[0] }
         return @($result)


### PR DESCRIPTION
Fixes #654

In GUI mode `Invoke-NonBlocking` runs the scriptblock in a separate runspace and called `EndInvoke` without inspecting `$ps.HadErrors` / `$ps.Streams.Error`. Every GUI-mode op writing non-terminating errors (app removal with `-ErrorAction Continue`, winget uninstall, `Disable-ScheduledTask`, `Disable-WindowsOptionalFeature`) had its errors silently discarded on `Dispose` - no feedback on failure.

This forwards the runspace error stream to the caller's error stream after `EndInvoke`:
```powershell
if ($ps.HadErrors) {
    foreach ($runspaceError in $ps.Streams.Error) {
        Write-Error -ErrorRecord $runspaceError
    }
}
```
Root cause **verified live on Windows 11** (`HadErrors=True`, `Streams.Error.Count` > 0, caller saw nothing). File parses clean.

> Note: this surfaces previously-hidden errors; the maintainer may want to filter expected ones (e.g. removing a not-installed app) as a follow-up. Swallowing all of them is the bug being fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixes a bug in `Invoke-NonBlocking` where errors generated during GUI mode operations are silently discarded. The function now inspects the background PowerShell runspace's error stream after `EndInvoke()` and forwards any non-terminating errors to the caller using `Write-Error`. This prevents operations like app removal, winget uninstall, scheduled task disabling, and optional feature toggling from failing silently with no user feedback.

## Changes

- **Scripts/Threading/Invoke-NonBlocking.ps1**: Added error stream inspection that checks `$ps.HadErrors` and re-emits errors from `$ps.Streams.Error` to the caller's error stream before runspace disposal (+9 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---
**Test environment:** Windows 11 25H2 (build 26200.8655), Windows PowerShell 5.1.26100.8655, .NET 4.0.30319.42000

Runspace error handling is a Windows PowerShell 5.1 + .NET 4.x behaviour, build-independent across Windows 11 builds (all ship PowerShell 5.1); only this build was exercised.