### PR TITLE
fix(app-removal): detect installed OneDrive in the "Only show installed" filter

### DIFF
--- a/Scripts/FileIO/LoadAppsDetailsFromJson.ps1
+++ b/Scripts/FileIO/LoadAppsDetailsFromJson.ps1
@@ -32,10 +32,6 @@ function LoadAppsDetailsFromJson {
                     $isInstalled = $true
                     break
                 }
-                # OneDrive is a Win32 app (per-machine or per-user), not an Appx package, and
-                # winget lists it under its ARP display name ("Microsoft OneDrive") rather than
-                # the "Microsoft.OneDrive" id, so neither the Get-AppxPackage nor the winget
-                # string match above detects it. Fall back to its install footprint.
                 if (($appId -eq "Microsoft.OneDrive") -and (
                         (Test-Path "$env:ProgramFiles\Microsoft OneDrive\OneDrive.exe") -or
                         (Test-Path "$env:LOCALAPPDATA\Microsoft\OneDrive\OneDrive.exe")

--- a/Scripts/FileIO/LoadAppsDetailsFromJson.ps1
+++ b/Scripts/FileIO/LoadAppsDetailsFromJson.ps1
@@ -32,6 +32,17 @@ function LoadAppsDetailsFromJson {
                     $isInstalled = $true
                     break
                 }
+                # OneDrive is a Win32 app (per-machine or per-user), not an Appx package, and
+                # winget lists it under its ARP display name ("Microsoft OneDrive") rather than
+                # the "Microsoft.OneDrive" id, so neither the Get-AppxPackage nor the winget
+                # string match above detects it. Fall back to its install footprint.
+                if (($appId -eq "Microsoft.OneDrive") -and (
+                        (Test-Path "$env:ProgramFiles\Microsoft OneDrive\OneDrive.exe") -or
+                        (Test-Path "$env:LOCALAPPDATA\Microsoft\OneDrive\OneDrive.exe")
+                    )) {
+                    $isInstalled = $true
+                    break
+                }
             }
             if (-not $isInstalled) { continue }
         }


### PR DESCRIPTION
## Problem
Closes #605. When **Only show installed apps** is enabled, OneDrive is hidden from the app-removal list even though it is installed.

## Root cause
The installed-state filter in `Scripts/FileIO/LoadAppsDetailsFromJson.ps1` treats an app as installed only if `Get-AppxPackage -Name <AppId>` returns a package, or the `winget list` output contains the literal AppId substring (e.g. `*Microsoft.OneDrive*`).

OneDrive (AppId `Microsoft.OneDrive` in Apps.json) satisfies neither:
- It is a Win32 app, not an Appx package, so `Get-AppxPackage -Name Microsoft.OneDrive` returns nothing (only the unrelated `Microsoft.OneDriveSync` Appx exists).
- `winget list` reports it under its ARP display name `Microsoft OneDrive` (with a space), not the dotted `Microsoft.OneDrive` id, so the substring match fails. When the script runs elevated, a per-user OneDrive install can also be invisible to winget in the elevated context.

The code already carries a `Microsoft.Edge` special case for the same class of id/name mismatch; OneDrive needs the same treatment.

## Fix
Add a OneDrive fallback that checks its install footprint, mirroring the existing Edge case:
- `%ProgramFiles%\Microsoft OneDrive\OneDrive.exe` (per-machine), or
- `%LOCALAPPDATA%\Microsoft\OneDrive\OneDrive.exe` (per-user).

## Verification
Verified on Windows 11 25H2 (build 26200.8655, Windows PowerShell 5.1.26100.8655):
- `Get-AppxPackage *OneDrive*` returns only `Microsoft.OneDriveSync`, not `Microsoft.OneDrive`.
- OneDrive is installed at `C:\Program Files\Microsoft OneDrive\OneDrive.exe`, ARP DisplayName `Microsoft OneDrive` under HKLM.
- File is parse-clean via `[Parser]::ParseFile`.

Detection-only change; it does not alter how OneDrive is removed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes OneDrive detection in the “Only show installed apps” filter for the Win11Debloat app-removal list. With the filter enabled, OneDrive was incorrectly hidden even when it was installed.

The root cause is that OneDrive is a Win32 app (not an Appx package), so the existing detection logic in `Scripts/FileIO/LoadAppsDetailsFromJson.ps1` fails: `Get-AppxPackage -Name Microsoft.OneDrive` returns nothing, and the `winget list`/Apps.json AppId matching doesn’t line up due to ARP display-name differences and potential invisibility of per-user installations when running elevated.

The fix adds a OneDrive-specific fallback (mirroring the existing Microsoft.Edge special case): when the current `AppId` is `Microsoft.OneDrive`, the script now checks for `OneDrive.exe` at either `%ProgramFiles%\Microsoft OneDrive\OneDrive.exe` (per-machine) or `%LOCALAPPDATA%\Microsoft\OneDrive\OneDrive.exe` (per-user). If either path exists, the app is treated as installed. This is a detection-only change and does not alter OneDrive removal behavior. It was verified on Windows 11 25H2 (build 26200.8655).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->