### PR TITLE
fix(app-removal): detect WinGet uninstall failures by exit code, not English text

### DIFF
--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -82,12 +82,16 @@ function RemoveApps {
             }
             else {
                 # Uninstall app via WinGet
-                $wingetOutput = Invoke-NonBlocking -ScriptBlock {
+                $wingetResult = Invoke-NonBlocking -ScriptBlock {
                     param($appId)
-                    winget uninstall --accept-source-agreements --disable-interactivity --id $appId
+                    $output = winget uninstall --accept-source-agreements --disable-interactivity --id $appId
+                    [PSCustomObject]@{ ExitCode = $LASTEXITCODE; Output = $output }
                 } -ArgumentList $app
 
-                $wingetFailed = Select-String -InputObject $wingetOutput -Pattern "Uninstall failed with exit code|No installed package found matching input criteria|No package found matching input criteria" -SimpleMatch:$false
+                # winget reports success/failure via its exit code, which is locale-independent.
+                # The previous match on English console text silently passed on non-English Windows.
+                # Treat a null result (timed out / not run) or any non-zero exit code as a failure.
+                $wingetFailed = ($null -eq $wingetResult) -or ($wingetResult.ExitCode -ne 0)
                 if ($isEdgeId) {
                     if (-not $wingetFailed) {
                         $edgeUninstallSucceeded = $true
@@ -116,6 +120,11 @@ function RemoveApps {
                             ForceRemoveEdge
                         }
                     }
+                }
+                elseif ($wingetFailed) {
+                    # OneDrive is the only other app removed via WinGet; surface the failure
+                    # instead of silently continuing (previously its result was never checked).
+                    Write-Host "Unable to uninstall $app via WinGet" -ForegroundColor Red
                 }
             }
 

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -84,6 +84,7 @@ function RemoveApps {
                 # Uninstall app via WinGet
                 $wingetResult = Invoke-NonBlocking -ScriptBlock {
                     param($appId)
+                    $global:LASTEXITCODE = 0
                     $output = winget uninstall --accept-source-agreements --disable-interactivity --id $appId
                     [PSCustomObject]@{ ExitCode = $LASTEXITCODE; Output = $output }
                 } -ArgumentList $app
@@ -122,8 +123,6 @@ function RemoveApps {
                     }
                 }
                 elseif ($wingetFailed) {
-                    # OneDrive is the only other app removed via WinGet; surface the failure
-                    # instead of silently continuing (previously its result was never checked).
                     Write-Host "Unable to uninstall $app via WinGet" -ForegroundColor Red
                 }
             }


### PR DESCRIPTION
## Problem
Fixes #657. The WinGet uninstall path in `Scripts/AppRemoval/RemoveApps.ps1` judges success by string-matching English console text, and never checks the result for OneDrive.

## Two bugs, one root cause
**Locale-dependent detection.** `$wingetFailed` was derived from a `Select-String` match on `"Uninstall failed with exit code| No installed package found... | No package found..."`. On non-English Windows the winget output is localized, the patterns miss, and a failed uninstall reads as success. For Edge that set `$edgeUninstallSucceeded = $true` and the force-uninstall fallback was never offered.

**OneDrive result discarded.** `$wingetFailed` was only used inside `if ($isEdgeId)`. OneDrive is removed via WinGet too but is not an Edge id, so its failure was silently ignored on every locale.

## Fix
winget reports success/failure through its exit code, which is locale-independent ([docs](https://learn.microsoft.com/windows/package-manager/winget/troubleshooting#exit-codes)). The exit code was being thrown away because the `winget` call runs inside an `Invoke-NonBlocking` runspace and only the text output was returned.

- Capture `$LASTEXITCODE` inside the scriptblock and return it alongside the output.
- `$wingetFailed = ($null -eq $wingetResult) -or ($wingetResult.ExitCode -ne 0)` -- a null result (timeout / not run) or any non-zero code is a failure.
- Add an `elseif ($wingetFailed)` for the OneDrive case so its failures are surfaced (`Unable to uninstall <app> via WinGet`).

## Behavior change
- Edge: force-uninstall fallback now triggers on real failures regardless of UI language (previously English-only).
- OneDrive: a failed uninstall now prints an error instead of nothing.
- Success path and the actual removal mechanism are unchanged.

## Verification
- Reviewed against `master` @ `8289417`; file is parse-clean via `[Parser]::ParseFile`.
- winget exit-code behavior confirmed from Microsoft Learn; prior issue #202 shows winget surfacing a real non-zero exit code.
- The WinGet uninstall path is destructive, so it was not executed live -- this is a code-level fix verified by inspection and parse.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Fixed two related WinGet uninstall issues in `Scripts/AppRemoval/RemoveApps.ps1` that caused uninstall failures to be misreported as success on non-English Windows and prevented OneDrive uninstall failures from being surfaced.

## Changes

Updated `Scripts/AppRemoval/RemoveApps.ps1` to determine WinGet uninstall success/failure using WinGet’s locale-independent process exit code instead of matching English console output:

- Replaced locale-dependent `Select-String` matching of English uninstall failure text with exit-code checking
- Updated the `Invoke-NonBlocking` scriptblock to capture `$LASTEXITCODE` and return it (alongside output) so it isn’t lost
- Changed failure detection to: `$wingetFailed = ($null -eq $wingetResult) -or ($wingetResult.ExitCode -ne 0)`
- Added an additional failure-handling path (`elseif ($wingetFailed)`) for non-Edge WinGet removals (including OneDrive) so uninstall failures emit an explicit red error message instead of being silently ignored
- Ensured the WinGet uninstall path includes OneDrive/Edge and the additional Edge app-id `XP9CXNGPPJ97XX`

Edge force-uninstall fallback is now correctly triggered on failed uninstalls across Windows locales since it no longer depends on localized console text.

## Impact

- **Locale-independent detection**: Uninstall failure is now determined by WinGet’s exit code (0 success, non-zero failure), avoiding false “success” reports on non-English systems
- **Edge force-uninstall fallback restored**: Failed Edge uninstalls correctly trigger the force-uninstall fallback regardless of Windows language
- **OneDrive failure visibility**: OneDrive removal failures are no longer silently ignored; users receive error messaging when WinGet uninstall fails

## Lines changed

+11/-3
<!-- end of auto-generated comment: release notes by coderabbit.ai -->