### PR TITLE
Replace FocusHelper C# compilation with WPF Activate() to fix temp DLL access-denied errors

### DIFF
--- a/Scripts/GUI/Show-ApplyModal.ps1
+++ b/Scripts/GUI/Show-ApplyModal.ps1
@@ -7,26 +7,6 @@ function Show-ApplyModal {
     )
     
     Add-Type -AssemblyName PresentationFramework,PresentationCore,WindowsBase | Out-Null
-
-    # P/Invoke helpers for forcing focus back after Explorer restart
-    if (-not ([System.Management.Automation.PSTypeName]'Win11Debloat.FocusHelper').Type) {
-        Add-Type -Namespace Win11Debloat -Name FocusHelper -MemberDefinition @'
-            [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
-            [DllImport("user32.dll")] public static extern IntPtr GetForegroundWindow();
-            [DllImport("user32.dll")] public static extern uint GetWindowThreadProcessId(IntPtr hWnd, IntPtr lpdwProcessId);
-            [DllImport("user32.dll")] public static extern bool AttachThreadInput(uint idAttach, uint idAttachTo, bool fAttach);
-            [DllImport("kernel32.dll")] public static extern uint GetCurrentThreadId();
-
-            public static void ForceActivate(IntPtr hwnd) {
-                IntPtr fg = GetForegroundWindow();
-                uint fgThread = GetWindowThreadProcessId(fg, IntPtr.Zero);
-                uint myThread = GetCurrentThreadId();
-                if (fgThread != myThread) AttachThreadInput(myThread, fgThread, true);
-                SetForegroundWindow(hwnd);
-                if (fgThread != myThread) AttachThreadInput(myThread, fgThread, false);
-            }
-'@
-    }
     
     $usesDarkMode = GetSystemUsesDarkMode
     
@@ -133,8 +113,7 @@ function Show-ApplyModal {
                 # Wait for Explorer to finish relaunching, then reclaim focus.
                 Start-Sleep -Milliseconds 800
                 $applyWindow.Dispatcher.Invoke([action]{
-                    $hwnd = (New-Object System.Windows.Interop.WindowInteropHelper($applyWindow)).Handle
-                    [Win11Debloat.FocusHelper]::ForceActivate($hwnd)
+                    $applyWindow.Activate()
                 })
             }
             


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

The Explorer restart focus-reclaim logic has been simplified by replacing the C# P/Invoke helper approach with WPF's native `Activate()` method.

**Previous approach:**
The script injected a C# P/Invoke helper (`Win11Debloat.FocusHelper`) and used it to force window foreground focus after relaunching Explorer via `SetForegroundWindow`, employing thread-attachment techniques (`AttachThreadInput`, `GetForegroundWindow`, etc.).

**New approach:**
After Explorer is restarted, focus is reclaimed by directly calling `$applyWindow.Activate()` on the apply modal window, bypassing the compiled C# helper entirely.

This change eliminates temporary DLL access-denied errors that were occurring with the compilation-based approach.

**Impact:**
- Lines changed: +1/-22
- The focus reclaim logic is now more straightforward and leverages WPF's built-in windowing capabilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->