### PR TITLE
Guard against loading, saving & executing undefined features

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -368,7 +368,7 @@
       "Label": "Create a system restore point",
       "Category": null,
       "RegistryKey": null,
-      "ApplyText": null,
+      "ApplyText": "Creating system restore point",
       "UndoLabel": null,
       "ApplyUndoText": null,
       "RegistryUndoKey": null,

--- a/Scripts/CLI/PrintPendingChanges.ps1
+++ b/Scripts/CLI/PrintPendingChanges.ps1
@@ -45,11 +45,6 @@ function PrintPendingChanges {
                 continue
             }
             default {
-                # Skip unknown parameters that aren't defined in Features.json
-                if (-not $script:Features -or -not $script:Features.ContainsKey($parameterName)) {
-                    continue
-                }
-
                 $message = $script:Features[$parameterName].Label
                 Write-Output "- $message"
                 continue

--- a/Scripts/CLI/PrintPendingChanges.ps1
+++ b/Scripts/CLI/PrintPendingChanges.ps1
@@ -45,14 +45,13 @@ function PrintPendingChanges {
                 continue
             }
             default {
-                if ($script:Features -and $script:Features.ContainsKey($parameterName)) {
-                    $message = $script:Features[$parameterName].Label
-                    Write-Output "- $message"
+                # Skip unknown parameters that aren't defined in Features.json
+                if (-not $script:Features -or -not $script:Features.ContainsKey($parameterName)) {
+                    continue
                 }
-                else {
-                    # Fallback: show the parameter name if no feature description is available
-                    Write-Output "- $parameterName"
-                }
+
+                $message = $script:Features[$parameterName].Label
+                Write-Output "- $message"
                 continue
             }
         }

--- a/Scripts/Features/BackupRegistryFeatureSelection.ps1
+++ b/Scripts/Features/BackupRegistryFeatureSelection.ps1
@@ -1,17 +1,3 @@
-function Get-FeatureId {
-    param(
-        [Parameter(Mandatory)]
-        $Feature
-    )
-
-    $featureId = [string]$Feature.FeatureId
-    if ([string]::IsNullOrWhiteSpace($featureId)) {
-        throw 'Selected feature is missing required FeatureId.'
-    }
-
-    return $featureId
-}
-
 function Get-RegistryBackedFeatures {
     param(
         [object[]]$Features = @()

--- a/Scripts/Features/BackupRegistryFeatureSelection.ps1
+++ b/Scripts/Features/BackupRegistryFeatureSelection.ps1
@@ -1,3 +1,10 @@
+<#
+    .SYNOPSIS
+        Filters a list of features to those that have a non-empty RegistryKey.
+
+    .PARAMETER Features
+        An array of feature objects to filter.
+#>
 function Get-RegistryBackedFeatures {
     param(
         [object[]]$Features = @()

--- a/Scripts/Features/BackupRegistryState.ps1
+++ b/Scripts/Features/BackupRegistryState.ps1
@@ -1,3 +1,18 @@
+<#
+    .SYNOPSIS
+        Creates a timestamped JSON backup of registry state for selected features.
+
+    .DESCRIPTION
+        Resolves selected and undo features from the provided keys, captures their
+        registry state, and saves the result as a JSON file in the Backups/ folder.
+        Returns the file path on success, $null if no registry-backed features exist.
+
+    .PARAMETER ActionableKeys
+        Param keys from $script:Params to resolve into apply features.
+
+    .PARAMETER ExtraFeatures
+        Additional synthetic feature objects (e.g. undo features) to include.
+#>
 function New-RegistrySettingsBackup {
     param(
         [string[]]$ActionableKeys,
@@ -32,6 +47,13 @@ function New-RegistrySettingsBackup {
     return $backupFilePath
 }
 
+<#
+    .SYNOPSIS
+        Resolves param keys into deduplicated feature objects from the catalog.
+
+    .PARAMETER ActionableKeys
+        Param keys to look up in $script:Features.
+#>
 function Get-SelectedFeatures {
     param(
         [string[]]$ActionableKeys
@@ -55,6 +77,23 @@ function Get-SelectedFeatures {
     return @($selectedFeatures.ToArray())
 }
 
+<#
+    .SYNOPSIS
+        Builds the full backup payload object from selected and undo features.
+
+    .DESCRIPTION
+        Deduplicates feature IDs, resolves registry capture plans, snapshots all
+        registry keys, and assembles the final backup hashtable with metadata.
+
+    .PARAMETER SelectedFeatures
+        Feature objects from the apply side.
+
+    .PARAMETER UndoFeatures
+        Synthetic feature objects from the undo side.
+
+    .PARAMETER CreatedAt
+        Timestamp recorded in the backup metadata.
+#>
 function Get-RegistryBackupPayload {
     param(
         [object[]]$SelectedFeatures = @(),

--- a/Scripts/Features/BackupRegistryState.ps1
+++ b/Scripts/Features/BackupRegistryState.ps1
@@ -46,8 +46,7 @@ function Get-SelectedFeatures {
         $feature = $script:Features[$paramKey]
         if (-not $feature) { continue }
 
-        $featureId = Get-FeatureId -Feature $feature
-
+        $featureId = [string]$feature.FeatureId
         if ($selectedFeatureIds.Add($featureId)) {
             $selectedFeatures.Add($feature)
         }
@@ -67,8 +66,7 @@ function Get-RegistryBackupPayload {
     $selectedFeatureIds = New-Object System.Collections.Generic.List[string]
     $seenSelectedFeatureIds = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     foreach ($feature in $SelectedFeatures) {
-        $featureId = Get-FeatureId -Feature $feature
-
+        $featureId = [string]$feature.FeatureId
         if ($seenSelectedFeatureIds.Add($featureId)) {
             $selectedFeatureIds.Add($featureId)
         }
@@ -77,8 +75,7 @@ function Get-RegistryBackupPayload {
     $selectedUndoFeatureIds = New-Object System.Collections.Generic.List[string]
     $seenUndoFeatureIds = New-Object 'System.Collections.Generic.HashSet[string]' ([System.StringComparer]::OrdinalIgnoreCase)
     foreach ($feature in $UndoFeatures) {
-        $featureId = Get-FeatureId -Feature $feature
-
+        $featureId = [string]$feature.FeatureId
         if ($seenUndoFeatureIds.Add($featureId)) {
             $selectedUndoFeatureIds.Add($featureId)
         }

--- a/Scripts/Features/GetCurrentTweakState.ps1
+++ b/Scripts/Features/GetCurrentTweakState.ps1
@@ -24,7 +24,6 @@ function Test-FeatureApplied {
         [string]$FeatureId
     )
 
-    if (-not $script:Features.ContainsKey($FeatureId)) { return $false }
     $feature = $script:Features[$FeatureId]
 
     switch ($FeatureId) {

--- a/Scripts/Features/GetCurrentTweakState.ps1
+++ b/Scripts/Features/GetCurrentTweakState.ps1
@@ -1,6 +1,10 @@
-# Tests whether the registry operations in a feature's .reg file currently match the live registry.
-# Returns $true if ALL operations in the apply reg file match current system state.
-# Returns $false if the feature has no RegistryKey, the file is missing, or any operation mismatches.
+<#
+    .SYNOPSIS
+        Maps a .reg file value type string to its RegistryValueKind enum.
+
+    .PARAMETER Operation
+        A parsed .reg operation object containing a ValueType property.
+#>
 function Get-ExpectedRegistryValueKind {
     param(
         [Parameter(Mandatory)]
@@ -18,6 +22,19 @@ function Get-ExpectedRegistryValueKind {
     }
 }
 
+<#
+    .SYNOPSIS
+        Tests whether a feature's registry operations currently match the live registry.
+
+    .DESCRIPTION
+        Returns $true when ALL operations in the apply .reg file match current system
+        state. Returns $false if the feature has no RegistryKey, the reg file is
+        missing, or any operation mismatches. Special-cased features (Widgets, Store
+        suggestions, Windows Sandbox, WSL) bypass .reg checking entirely.
+
+    .PARAMETER FeatureId
+        The feature identifier to test.
+#>
 function Test-FeatureApplied {
     param (
         [Parameter(Mandatory)]
@@ -146,8 +163,18 @@ function Test-FeatureApplied {
     return $true
 }
 
-# Returns the 1-based index of the UiGroup option whose features all match current system state,
-# or 0 if no option fully matches (meaning the current state is unknown / "No Change").
+<#
+    .SYNOPSIS
+        Returns the 1-based index of the UiGroup option whose features all match
+        current system state.
+
+    .DESCRIPTION
+        Returns 0 if no option fully matches, meaning the current state is unknown
+        or represents "No Change".
+
+    .PARAMETER Group
+        A UiGroup object whose Values array contains options with FeatureIds.
+#>
 function Get-CurrentGroupActiveIndex {
     param (
         [Parameter(Mandatory)]

--- a/Scripts/Features/InvokeChanges.ps1
+++ b/Scripts/Features/InvokeChanges.ps1
@@ -17,11 +17,10 @@ function Invoke-FeatureApply {
 
     # Resolve feature metadata from Features.json
     $feature = $script:Features[$FeatureId]
-
-    $applyText = if ($feature.ApplyText) { $feature.ApplyText } else { $FeatureId }
+    $applyText = $feature.ApplyText
 
     # ---- Registry-backed features: import .reg file, then handle side effects ----
-    if ($feature -and $feature.RegistryKey) {
+    if ($feature.RegistryKey) {
         ImportRegistryFile "> $applyText..." $feature.RegistryKey
 
         # Post-import side effects for specific features
@@ -174,15 +173,13 @@ function Invoke-FeatureUndo {
             return
         }
         'EnableWindowsSandbox' {
-            $undoText = if ($feature) { $feature.ApplyUndoText } else { 'Disabling Windows Sandbox' }
-            Write-Host "> $undoText..."
+            Write-Host "> $($feature.ApplyUndoText)..."
             DisableWindowsFeature 'Containers-DisposableClientVM'
             Write-Host ""
             return
         }
         'EnableWindowsSubsystemForLinux' {
-            $undoText = if ($feature) { $feature.ApplyUndoText } else { 'Disabling Windows Subsystem for Linux' }
-            Write-Host "> $undoText..."
+            Write-Host "> $($feature.ApplyUndoText)..."
             DisableWindowsFeature 'Microsoft-Windows-Subsystem-Linux'
             DisableWindowsFeature 'VirtualMachinePlatform'
             Write-Host ""
@@ -243,7 +240,7 @@ function Invoke-ApplyFeatures {
 
         # Resolve display name for the progress indicator
         $f = $script:Features[$featureId]
-        $displayName = if ($f.ApplyText) { $f.ApplyText } else { $featureId }
+        $displayName = $f.ApplyText
 
         if ($script:ApplyProgressCallback) {
             & $script:ApplyProgressCallback $step $TotalSteps $displayName

--- a/Scripts/Features/InvokeChanges.ps1
+++ b/Scripts/Features/InvokeChanges.ps1
@@ -16,12 +16,9 @@ function Invoke-FeatureApply {
     )
 
     # Resolve feature metadata from Features.json
-    $feature = $null
-    if ($script:Features.ContainsKey($FeatureId)) {
-        $feature = $script:Features[$FeatureId]
-    }
-    
-    $applyText = if ($feature -and $feature.ApplyText) { $feature.ApplyText } else { $FeatureId }
+    $feature = $script:Features[$FeatureId]
+
+    $applyText = if ($feature.ApplyText) { $feature.ApplyText } else { $FeatureId }
 
     # ---- Registry-backed features: import .reg file, then handle side effects ----
     if ($feature -and $feature.RegistryKey) {
@@ -245,15 +242,8 @@ function Invoke-ApplyFeatures {
         if ($script:CancelRequested) { return }
 
         # Resolve display name for the progress indicator
-        $displayName = $featureId
-        if ($script:Features.ContainsKey($featureId)) {
-            $f = $script:Features[$featureId]
-            if ($f.ApplyText) {
-                $displayName = $f.ApplyText
-            } elseif ($f.Label) {
-                $displayName = $f.Label
-            }
-        }
+        $f = $script:Features[$featureId]
+        $displayName = if ($f.ApplyText) { $f.ApplyText } else { $featureId }
 
         if ($script:ApplyProgressCallback) {
             & $script:ApplyProgressCallback $step $TotalSteps $displayName
@@ -338,8 +328,6 @@ function Invoke-AllChanges {
         if ($script:ControlParams -contains $key) { continue }
         if ($key -eq 'Apps') { continue }
         if ($key -eq 'CreateRestorePoint') { continue }
-        # Skip unknown parameters that aren't defined in Features.json
-        if (-not $script:Features.ContainsKey($key)) { continue }
         $applyIds += $key
     }
     $undoIds = @($script:UndoParams.Keys)
@@ -347,7 +335,6 @@ function Invoke-AllChanges {
     # ---- Determine if registry backup is needed ----
     $needsBackup = $false
     foreach ($id in $applyIds) {
-        if (-not $script:Features.ContainsKey($id)) { continue }
         $f = $script:Features[$id]
         if ($f -and -not [string]::IsNullOrWhiteSpace([string]$f.RegistryKey)) {
             $needsBackup = $true

--- a/Scripts/Features/InvokeChanges.ps1
+++ b/Scripts/Features/InvokeChanges.ps1
@@ -338,6 +338,8 @@ function Invoke-AllChanges {
         if ($script:ControlParams -contains $key) { continue }
         if ($key -eq 'Apps') { continue }
         if ($key -eq 'CreateRestorePoint') { continue }
+        # Skip unknown parameters that aren't defined in Features.json
+        if (-not $script:Features.ContainsKey($key)) { continue }
         $applyIds += $key
     }
     $undoIds = @($script:UndoParams.Keys)

--- a/Scripts/FileIO/LoadSettings.ps1
+++ b/Scripts/FileIO/LoadSettings.ps1
@@ -21,6 +21,9 @@ function LoadSettings {
 
         $feature = $script:Features[$setting.Name]
 
+        # Skip unknown settings that aren't defined in Features.json
+        if (-not $feature) { continue }
+
         # Check version and feature compatibility using Features.json
         if (($feature.MinVersion -and $WinVersion -lt $feature.MinVersion) -or ($feature.MaxVersion -and $WinVersion -gt $feature.MaxVersion) -or ($feature.FeatureId -eq 'DisableModernStandbyNetworking' -and (-not $script:ModernStandbySupported))) {
            continue

--- a/Scripts/FileIO/SaveSettings.ps1
+++ b/Scripts/FileIO/SaveSettings.ps1
@@ -11,7 +11,7 @@ function SaveSettings {
     }
     
     foreach ($param in $script:Params.Keys) {
-        if ($script:ControlParams -notcontains $param) {
+        if ($script:ControlParams -notcontains $param -and $script:Features.ContainsKey($param)) {
             $value = $script:Params[$param]
 
             $settings.Settings += @{

--- a/Scripts/GUI/MainWindow-Deployment.ps1
+++ b/Scripts/GUI/MainWindow-Deployment.ps1
@@ -1,29 +1,8 @@
 # MainWindow-Deployment.ps1
 # Overview generation, pending tweak actions, feature labels, tweak preset maps, apply logic, user mode state, user selection, and validation.
 
-function Get-FeatureLabel {
-    param(
-        [string]$FeatureId,
-        $FallbackLabel = $null
-    )
-
-    $label = $script:FeatureLabelLookup[$FeatureId]
-    if (-not [string]::IsNullOrWhiteSpace([string]$label)) {
-        return [string]$label
-    }
-
-    if (-not [string]::IsNullOrWhiteSpace([string]$FallbackLabel)) {
-        return [string]$FallbackLabel
-    }
-
-    return [string]$FeatureId
-}
-
 function Get-UndoFeatureLabel {
-    param(
-        [string]$FeatureId,
-        $FallbackLabel = $null
-    )
+    param([string]$FeatureId)
 
     $undoLabel = $script:UndoFeatureLabelLookup[$FeatureId]
     if (-not [string]::IsNullOrWhiteSpace([string]$undoLabel)) {
@@ -31,8 +10,7 @@ function Get-UndoFeatureLabel {
     }
 
     # Fall back to the regular label (prefixed for undo context)
-    $label = Get-FeatureLabel -FeatureId $FeatureId -FallbackLabel $FallbackLabel
-    return [string]$label
+    return [string]$script:FeatureLabelLookup[$FeatureId]
 }
 
 function Get-PendingTweakActions {
@@ -69,14 +47,14 @@ function Get-PendingTweakActions {
                 $actions.Add([PSCustomObject]@{
                         Action    = 'Apply'
                         FeatureId = [string]$mapping.FeatureId
-                        Label     = (Get-FeatureLabel -FeatureId $mapping.FeatureId -FallbackLabel $mapping.Label)
+                        Label     = [string]$script:FeatureLabelLookup[$mapping.FeatureId]
                     })
             }
             elseif ($wasApplied -and -not $isNowChecked) {
                 $actions.Add([PSCustomObject]@{
                         Action    = 'Undo'
                         FeatureId = [string]$mapping.FeatureId
-                        Label     = (Get-FeatureLabel -FeatureId $mapping.FeatureId -FallbackLabel $mapping.Label)
+                        Label     = [string]$script:FeatureLabelLookup[$mapping.FeatureId]
                     })
             }
         }
@@ -101,7 +79,7 @@ function Get-PendingTweakActions {
                     $actions.Add([PSCustomObject]@{
                             Action    = 'Apply'
                             FeatureId = [string]$fid
-                            Label     = (Get-FeatureLabel -FeatureId $fid)
+                            Label     = [string]$script:FeatureLabelLookup[$fid]
                         })
                 }
             }

--- a/Scripts/GUI/RestoreBackupDialogFeatureLists.ps1
+++ b/Scripts/GUI/RestoreBackupDialogFeatureLists.ps1
@@ -1,3 +1,11 @@
+<#
+    .SYNOPSIS
+        Creates a lightweight state object for the restore-backup dialog result.
+
+    .DESCRIPTION
+        Encapsulates the user's dialog choice (Result), the selected backup file
+        path, and the parsed backup payload so callers receive a single object.
+#>
 function New-RestoreDialogState {
     param(
         [string]$Result = 'Cancel',
@@ -8,6 +16,16 @@ function New-RestoreDialogState {
     return @{ Result = $Result; SelectedFile = $SelectedFile; Backup = $Backup }
 }
 
+<#
+    .SYNOPSIS
+        Looks up a feature definition by ID from the provided feature catalog.
+
+    .PARAMETER FeatureId
+        The identifier to search for (e.g. 'DisableTelemetry').
+
+    .PARAMETER Features
+        A hashtable loaded from Features.json (FeatureId -> feature object).
+#>
 function Get-RestoreDialogFeatureDefinition {
     param(
         [string]$FeatureId,
@@ -25,6 +43,21 @@ function Get-RestoreDialogFeatureDefinition {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Determines whether a feature can be automatically reverted via registry restore.
+
+    .DESCRIPTION
+        Returns $true when the feature has a non-empty RegistryKey, indicating
+        an apply .reg file exists that can be undone automatically. Features
+        with custom logic (no RegistryKey) must be manually reverted.
+
+    .PARAMETER FeatureId
+        The feature identifier to check.
+
+    .PARAMETER Features
+        A hashtable loaded from Features.json.
+#>
 function Test-RestoreDialogFeatureCanAutoRevert {
     param(
         [string]$FeatureId,
@@ -43,6 +76,20 @@ function Test-RestoreDialogFeatureCanAutoRevert {
     return $false
 }
 
+<#
+    .SYNOPSIS
+        Resolves a human-readable label for a feature shown in the restore dialog.
+
+    .DESCRIPTION
+        Returns the feature's Label from Features.json when found, falling back
+        to the raw FeatureId string. For null/empty FeatureIds returns 'Unknown feature'.
+
+    .PARAMETER FeatureId
+        The feature identifier to resolve a label for.
+
+    .PARAMETER Features
+        A hashtable loaded from Features.json.
+#>
 function Get-RestoreDialogFeatureDisplayLabel {
     param(
         [string]$FeatureId,
@@ -61,6 +108,21 @@ function Get-RestoreDialogFeatureDisplayLabel {
     return $FeatureId
 }
 
+<#
+    .SYNOPSIS
+        Checks whether a feature should appear in the restore dialog's overview list.
+
+    .DESCRIPTION
+        A feature is considered visible when it exists in the catalog and has
+        a non-empty Category (meaning it belongs to a UI grouping). Features
+        without a Category are hidden from the overview.
+
+    .PARAMETER FeatureId
+        The feature identifier to check.
+
+    .PARAMETER Features
+        A hashtable loaded from Features.json.
+#>
 function Test-RestoreDialogFeatureVisibleInOverview {
     param(
         [string]$FeatureId,
@@ -79,6 +141,13 @@ function Test-RestoreDialogFeatureVisibleInOverview {
     return -not [string]::IsNullOrWhiteSpace([string]$featureDefinition.Category)
 }
 
+<#
+    .SYNOPSIS
+        Extracts deduplicated forward (apply) feature IDs from a backup payload.
+
+    .PARAMETER SelectedBackup
+        The parsed backup object containing a SelectedFeatures property.
+#>
 function Get-SelectedForwardFeatureIdsFromBackup {
     param($SelectedBackup)
 
@@ -99,6 +168,13 @@ function Get-SelectedForwardFeatureIdsFromBackup {
     return @($selectedFeatureIds.ToArray())
 }
 
+<#
+    .SYNOPSIS
+        Extracts deduplicated undo feature IDs from a backup payload.
+
+    .PARAMETER SelectedBackup
+        The parsed backup object containing a SelectedUndoFeatures property.
+#>
 function Get-SelectedUndoFeatureIdsFromBackup {
     param($SelectedBackup)
 
@@ -119,6 +195,13 @@ function Get-SelectedUndoFeatureIdsFromBackup {
     return @($selectedUndoFeatureIds.ToArray())
 }
 
+<#
+    .SYNOPSIS
+        Merges forward and undo feature IDs from a backup into a single deduplicated list.
+
+    .PARAMETER SelectedBackup
+        The parsed backup object containing SelectedFeatures and SelectedUndoFeatures.
+#>
 function Get-CombinedSelectedFeatureIdsFromBackup {
     param($SelectedBackup)
 
@@ -139,12 +222,34 @@ function Get-CombinedSelectedFeatureIdsFromBackup {
     return @($featureIds.ToArray())
 }
 
+<#
+    .SYNOPSIS
+        Convenience wrapper that returns all combined feature IDs from a backup.
+
+    .PARAMETER SelectedBackup
+        The parsed backup object.
+#>
 function Get-SelectedFeatureIdsFromBackup {
     param($SelectedBackup)
 
     return @(Get-CombinedSelectedFeatureIdsFromBackup -SelectedBackup $SelectedBackup)
 }
 
+<#
+    .SYNOPSIS
+        Splits selected feature IDs into revertible and non-revertible lists for display.
+
+    .DESCRIPTION
+        Iterates the provided feature IDs, filters to those visible in the overview,
+        and separates them into auto-revertible (has a RegistryKey) and non-revertible
+        (requires manual undo) buckets. Each entry includes a display label.
+
+    .PARAMETER SelectedFeatureIds
+        The list of feature IDs to categorize.
+
+    .PARAMETER Features
+        A hashtable loaded from Features.json.
+#>
 function Get-RestoreBackupFeatureLists {
     param(
         [string[]]$SelectedFeatureIds,

--- a/Scripts/GUI/RestoreBackupDialogFeatureLists.ps1
+++ b/Scripts/GUI/RestoreBackupDialogFeatureLists.ps1
@@ -54,7 +54,7 @@ function Get-RestoreDialogFeatureDisplayLabel {
     }
 
     $featureDefinition = Get-RestoreDialogFeatureDefinition -FeatureId $FeatureId -Features $Features
-    if ($featureDefinition -and -not [string]::IsNullOrWhiteSpace([string]$featureDefinition.Label)) {
+    if ($featureDefinition) {
         return [string]$featureDefinition.Label
     }
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -242,6 +242,10 @@ $script:Features = @{}
 try {
     $featuresData = Get-Content -Path $script:FeaturesFilePath -Raw | ConvertFrom-Json
     foreach ($feature in $featuresData.Features) {
+        if ([string]::IsNullOrWhiteSpace([string]$feature.FeatureId) -or [string]::IsNullOrWhiteSpace([string]$feature.Label) -or [string]::IsNullOrWhiteSpace([string]$feature.ApplyText)) {
+            Write-Warning "Feature '$($feature.FeatureId)' is missing a FeatureId, Label, or ApplyText in Features.json and will be skipped."
+            continue
+        }
         $script:Features[$feature.FeatureId] = $feature
     }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR hardens Win11Debloat against undefined/malformed features by validating feature definitions when loading `Features.json`, filtering settings persistence/loading to only known features, and removing (or tightening) fallback-to-raw-ID/name behaviors in execution/metadata paths. UI/CLI text and progress messaging now primarily rely on resolved feature metadata, so missing/invalid definitions don’t silently propagate through apply/undo/backup flows.

## Changes by file

**Win11Debloat.ps1**
- When loading `Config/Features.json`, it now skips any feature entry whose `FeatureId`, `Label`, or `ApplyText` is null/empty/whitespace (warning emitted) instead of adding it to `$script:Features`.

**Scripts/CLI/PrintPendingChanges.ps1**
- In the `default` case, pending change descriptions now resolve directly via `$script:Features[$parameterName].Label` (no fallback to the raw parameter name).

**Scripts/Features/InvokeChanges.ps1**
- `Invoke-FeatureApply` now resolves feature metadata via direct indexing (`$feature = $script:Features[$FeatureId]`) and uses `$feature.ApplyText` directly (no `ContainsKey`/fallback when metadata is missing).
- `Invoke-ApplyFeatures` resolves progress display name via `$f.ApplyText` after direct indexing (`$f = $script:Features[$featureId]`).
- `Invoke-FeatureUndo` for `EnableWindowsSandbox` / `EnableWindowsSubsystemForLinux` logs via `$feature.ApplyUndoText` directly (no computed fallback string).
- `Invoke-AllChanges` determines registry-backup needs by directly indexing `$script:Features[$id]` when checking registry keys.

**Scripts/FileIO/LoadSettings.ps1**
- `LoadSettings` now skips JSON settings entries whose `Name` is not present in `$script:Features`.

**Scripts/FileIO/SaveSettings.ps1**
- `SaveSettings` persists only non-control parameters that also exist in `$script:Features`.

**Scripts/GUI/RestoreBackupDialogFeatureLists.ps1**
- `Get-RestoreDialogFeatureDisplayLabel` returns the resolved `featureDefinition.Label` when the feature definition exists (even if the label is null/empty/whitespace); it only falls back to `FeatureId` when the definition itself is missing.

**Scripts/GUI/MainWindow-Deployment.ps1**
- Removed `Get-FeatureLabel`.
- Simplified `Get-UndoFeatureLabel` to accept only `FeatureId`, using `UndoFeatureLabelLookup[$FeatureId]` with fallback to `FeatureLabelLookup[$FeatureId]`.
- Updated pending action label population to use direct lookups from `$script:FeatureLabelLookup[$FeatureId]`.

**Scripts/Features/BackupRegistryFeatureSelection.ps1**
- Removed helper `Get-FeatureId` (registry-backed feature selection now relies on existing filtering for `RegistryKey`).

**Scripts/Features/BackupRegistryState.ps1**
- `Get-SelectedFeatures` / `Get-RegistryBackupPayload` now derive `featureId` directly from the feature object’s `[string]$feature.FeatureId` property (no helper call).

**Scripts/Features/GetCurrentTweakState.ps1**
- `Test-FeatureApplied` now indexes `$feature = $script:Features[$FeatureId]` without an early “missing feature” guard and relies on the later `if (-not $feature.RegistryKey) { return $false }` check.

**Scripts/Features/BackupRegistryFeatureSelection.ps1 / Config/Features.json**
- `Config/Features.json`: updated `CreateRestorePoint.ApplyText` from `null` to `"Creating system restore point"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->