### PR TITLE
Simplify Window management

### DIFF
--- a/Schemas/MainWindow.xaml
+++ b/Schemas/MainWindow.xaml
@@ -7,8 +7,8 @@
         SnapsToDevicePixels="True"
         WindowStartupLocation="CenterScreen"
         WindowStyle="None"
-        AllowsTransparency="True"
-        Background="Transparent"
+        AllowsTransparency="False"
+        Background="{DynamicResource AppBorderColor}"
         Foreground="{DynamicResource AppFgColor}">
     <shell:WindowChrome.WindowChrome>
         <shell:WindowChrome ResizeBorderThickness="5"

--- a/Scripts/GUI/MainWindow-WindowChrome.ps1
+++ b/Scripts/GUI/MainWindow-WindowChrome.ps1
@@ -1,71 +1,5 @@
 # MainWindow-WindowChrome.ps1
-# Window sizing, DPI-aware coordinate conversion, maximized-window taskbar-constraint helpers, and UI animations.
-
-function Register-MaximizedWindowHelper {
-    if (-not ([System.Management.Automation.PSTypeName]'Win11Debloat.MaximizedWindowHelper').Type) {
-        Add-Type -Namespace Win11Debloat -Name MaximizedWindowHelper `
-            -ReferencedAssemblies 'PresentationFramework','System.Windows.Forms','System.Drawing' `
-            -MemberDefinition @'
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct MINMAXINFO {
-                public POINT ptReserved, ptMaxSize, ptMaxPosition, ptMinTrackSize, ptMaxTrackSize;
-            }
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct POINT { public int x, y; }
-
-            [System.Runtime.InteropServices.DllImport("user32.dll")]
-            private static extern System.IntPtr MonitorFromWindow(System.IntPtr hwnd, uint dwFlags);
-
-            [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-            private static extern bool GetMonitorInfo(System.IntPtr hMonitor, ref MONITORINFO lpmi);
-
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct RECT {
-                public int Left, Top, Right, Bottom;
-            }
-
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-            private struct MONITORINFO {
-                public int cbSize;
-                public RECT rcMonitor;
-                public RECT rcWork;
-                public uint dwFlags;
-            }
-
-            public static System.IntPtr WmGetMinMaxInfoHook(
-                System.IntPtr hwnd, int msg, System.IntPtr wParam, System.IntPtr lParam, ref bool handled) {
-                if (msg == 0x0024) { // WM_GETMINMAXINFO
-                    var mmi = (MINMAXINFO)System.Runtime.InteropServices.Marshal.PtrToStructure(
-                        lParam, typeof(MINMAXINFO));
-
-                    const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
-                    var monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                    var monitorInfo = new MONITORINFO();
-                    monitorInfo.cbSize = System.Runtime.InteropServices.Marshal.SizeOf(typeof(MONITORINFO));
-
-                    if (monitor != System.IntPtr.Zero && GetMonitorInfo(monitor, ref monitorInfo)) {
-                        mmi.ptMaxPosition.x = monitorInfo.rcWork.Left - monitorInfo.rcMonitor.Left;
-                        mmi.ptMaxPosition.y = monitorInfo.rcWork.Top - monitorInfo.rcMonitor.Top;
-                        mmi.ptMaxSize.x     = monitorInfo.rcWork.Right - monitorInfo.rcWork.Left;
-                        mmi.ptMaxSize.y     = monitorInfo.rcWork.Bottom - monitorInfo.rcWork.Top;
-                    }
-                    else {
-                        var screen = System.Windows.Forms.Screen.FromHandle(hwnd);
-                        var wa = screen.WorkingArea;
-                        var bounds = screen.Bounds;
-                        mmi.ptMaxPosition.x = wa.Left - bounds.Left;
-                        mmi.ptMaxPosition.y = wa.Top - bounds.Top;
-                        mmi.ptMaxSize.x     = wa.Width;
-                        mmi.ptMaxSize.y     = wa.Height;
-                    }
-
-                    System.Runtime.InteropServices.Marshal.StructureToPtr(mmi, lParam, true);
-                }
-                return System.IntPtr.Zero;
-            }
-'@
-    }
-}
+# Window sizing, DPI-aware coordinate conversion, and UI animations.
 
 # Convert screen-pixel coordinates to WPF device-independent pixels (DIP)
 function ConvertTo-ScreenPointToDip {
@@ -118,16 +52,13 @@ function Update-MainWindowChrome {
     )
 
     $windowStateMaximized = [System.Windows.WindowState]::Maximized
-    $chrome = [System.Windows.Shell.WindowChrome]::GetWindowChrome($Window)
 
     if ($Window.WindowState -eq $windowStateMaximized) {
-        $MainBorder.Margin = [System.Windows.Thickness]::new(0)
+        $MainBorder.Margin = [System.Windows.SystemParameters]::WindowResizeBorderThickness
         $MainBorder.BorderThickness = [System.Windows.Thickness]::new(0)
         $MainBorder.CornerRadius = [System.Windows.CornerRadius]::new(0)
         $MainBorder.Effect = $null
         $TitleBarBackground.CornerRadius = [System.Windows.CornerRadius]::new(0)
-        # Zero out resize borders when maximized so the entire title bar row is draggable
-        if ($chrome) { $chrome.ResizeBorderThickness = [System.Windows.Thickness]::new(0) }
     }
     else {
         $MainBorder.Margin = [System.Windows.Thickness]::new(0)
@@ -135,7 +66,6 @@ function Update-MainWindowChrome {
         $MainBorder.CornerRadius = [System.Windows.CornerRadius]::new(8)
         $MainBorder.Effect = $NormalWindowShadow
         $TitleBarBackground.CornerRadius = [System.Windows.CornerRadius]::new(8, 8, 0, 0)
-        if ($chrome) { $chrome.ResizeBorderThickness = [System.Windows.Thickness]::new(5) }
     }
 }
 

--- a/Scripts/GUI/Show-MainWindow.ps1
+++ b/Scripts/GUI/Show-MainWindow.ps1
@@ -1,71 +1,6 @@
 ﻿function Show-MainWindow {
     Add-Type -AssemblyName PresentationFramework,PresentationCore,WindowsBase,System.Windows.Forms | Out-Null
 
-    # ---- Constrain maximized window to taskbar work area ----
-    if (-not ([System.Management.Automation.PSTypeName]'Win11Debloat.MaximizedWindowHelper').Type) {
-        Add-Type -Namespace Win11Debloat -Name MaximizedWindowHelper `
-            -ReferencedAssemblies 'PresentationFramework','System.Windows.Forms','System.Drawing' `
-            -MemberDefinition @'
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct MINMAXINFO {
-                public POINT ptReserved, ptMaxSize, ptMaxPosition, ptMinTrackSize, ptMaxTrackSize;
-            }
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct POINT { public int x, y; }
-
-            [System.Runtime.InteropServices.DllImport("user32.dll")]
-            private static extern System.IntPtr MonitorFromWindow(System.IntPtr hwnd, uint dwFlags);
-
-            [System.Runtime.InteropServices.DllImport("user32.dll", CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-            private static extern bool GetMonitorInfo(System.IntPtr hMonitor, ref MONITORINFO lpmi);
-
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
-            private struct RECT {
-                public int Left, Top, Right, Bottom;
-            }
-
-            [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential, CharSet = System.Runtime.InteropServices.CharSet.Auto)]
-            private struct MONITORINFO {
-                public int cbSize;
-                public RECT rcMonitor;
-                public RECT rcWork;
-                public uint dwFlags;
-            }
-
-            public static System.IntPtr WmGetMinMaxInfoHook(
-                System.IntPtr hwnd, int msg, System.IntPtr wParam, System.IntPtr lParam, ref bool handled) {
-                if (msg == 0x0024) { // WM_GETMINMAXINFO
-                    var mmi = (MINMAXINFO)System.Runtime.InteropServices.Marshal.PtrToStructure(
-                        lParam, typeof(MINMAXINFO));
-
-                    const uint MONITOR_DEFAULTTONEAREST = 0x00000002;
-                    var monitor = MonitorFromWindow(hwnd, MONITOR_DEFAULTTONEAREST);
-                    var monitorInfo = new MONITORINFO();
-                    monitorInfo.cbSize = System.Runtime.InteropServices.Marshal.SizeOf(typeof(MONITORINFO));
-
-                    if (monitor != System.IntPtr.Zero && GetMonitorInfo(monitor, ref monitorInfo)) {
-                        mmi.ptMaxPosition.x = monitorInfo.rcWork.Left - monitorInfo.rcMonitor.Left;
-                        mmi.ptMaxPosition.y = monitorInfo.rcWork.Top - monitorInfo.rcMonitor.Top;
-                        mmi.ptMaxSize.x     = monitorInfo.rcWork.Right - monitorInfo.rcWork.Left;
-                        mmi.ptMaxSize.y     = monitorInfo.rcWork.Bottom - monitorInfo.rcWork.Top;
-                    }
-                    else {
-                        var screen = System.Windows.Forms.Screen.FromHandle(hwnd);
-                        var wa = screen.WorkingArea;
-                        var bounds = screen.Bounds;
-                        mmi.ptMaxPosition.x = wa.Left - bounds.Left;
-                        mmi.ptMaxPosition.y = wa.Top - bounds.Top;
-                        mmi.ptMaxSize.x     = wa.Width;
-                        mmi.ptMaxSize.y     = wa.Height;
-                    }
-
-                    System.Runtime.InteropServices.Marshal.StructureToPtr(mmi, lParam, true);
-                }
-                return System.IntPtr.Zero;
-            }
-'@
-    }
-
     $WinVersion = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' CurrentBuild
     $usesDarkMode = GetSystemUsesDarkMode
 
@@ -123,12 +58,6 @@
     $window.Add_SourceInitialized({
         & $applyInitialWindowSize
         & $updateWindowChrome
-
-        $hwndHelper = New-Object System.Windows.Interop.WindowInteropHelper($window)
-        $hwndSource = [System.Windows.Interop.HwndSource]::FromHwnd($hwndHelper.Handle)
-        $hookMethod = [Win11Debloat.MaximizedWindowHelper].GetMethod('WmGetMinMaxInfoHook')
-        $hook = [System.Delegate]::CreateDelegate([System.Windows.Interop.HwndSourceHook], $hookMethod)
-        $hwndSource.AddHook($hook)
     })
 
     $window.Add_SizeChanged({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Simplified window chrome handling by removing maximized-window helper logic and the `WM_GETMINMAXINFO` taskbar work-area constraint hook from `Show-MainWindow`.
- Updated `Update-MainWindowChrome` to stop managing `WindowChrome.ResizeBorderThickness`, keeping only the border/title bar visual state changes when toggling maximized state.
- Changed the main window XAML to disable transparency and use `AppBorderColor` as the window background instead of a transparent background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->