### PR TITLE
Update start menu backup/restore with timestamped filenames

### DIFF
--- a/Scripts/Features/ReplaceStartMenu.ps1
+++ b/Scripts/Features/ReplaceStartMenu.ps1
@@ -193,6 +193,55 @@ function GetStartMenuUserNameFromPath {
 }
 
 
+<#
+    .SYNOPSIS
+    Returns the path to the latest start menu backup file for the given scope.
+
+    .DESCRIPTION
+    Resolves the LocalState folder for the specified scope and returns the
+    full path to the most recent Win11Debloat-StartBackup-*.bak file, or
+    $null if no backup exists.
+
+    For CurrentUser, uses $env:LOCALAPPDATA directly. For AllUsers, scans
+    every user profile.
+
+    .PARAMETER Scope
+    The scope to check: CurrentUser or AllUsers.
+
+    .EXAMPLE
+    $backupPath = Get-StartMenuBackupPath -Scope 'CurrentUser'
+
+    .EXAMPLE
+    $backupPath = Get-StartMenuBackupPath -Scope 'AllUsers'
+#>
+function Get-StartMenuBackupPath {
+    param(
+        [Parameter(Mandatory)]
+        [ValidateSet('CurrentUser', 'AllUsers')]
+        [string]$Scope
+    )
+
+    if ($Scope -eq 'CurrentUser') {
+        $localStateDir = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
+        $latestBackup = Get-ChildItem -Path (Join-Path $localStateDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
+            Sort-Object Name -Descending |
+            Select-Object -First 1
+        if ($latestBackup) { return $latestBackup.FullName }
+        return $null
+    }
+    else {
+        $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
+        $usersStartMenuPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
+        foreach ($startMenuPath in $usersStartMenuPaths) {
+            $latestBackup = Get-ChildItem -Path (Join-Path $startMenuPath.FullName 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
+                Sort-Object Name -Descending |
+                Select-Object -First 1
+            if ($latestBackup) { return $latestBackup.FullName }
+        }
+        return $null
+    }
+}
+
 
 <#
     .SYNOPSIS
@@ -232,12 +281,7 @@ function RestoreStartMenuFromBackup {
             Sort-Object Name -Descending |
             Select-Object -First 1
 
-        if ($latestBackup) {
-            $latestBackup.FullName
-        }
-        else {
-            $StartMenuBinFile + '.bak'
-        }
+        if ($latestBackup) { $latestBackup.FullName } else { $null }
     }
     else {
         $BackupFilePath
@@ -245,6 +289,14 @@ function RestoreStartMenuFromBackup {
     $restoreTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
     $restoreBackupFileName = "Win11Debloat-StartRestore-$restoreTimestamp.bak"
     $currentBinBackup = Join-Path (Split-Path $StartMenuBinFile -Parent) $restoreBackupFileName
+
+    if ([string]::IsNullOrWhiteSpace($backupBinFile)) {
+        return [PSCustomObject]@{
+            UserName = $userName
+            Result = $false
+            Message = "No start menu backup file found for user $userName."
+        }
+    }
 
     if ($script:Params.ContainsKey("WhatIf")) {
         Write-Host "[WhatIf] Restore start menu for user $userName from backup $backupBinFile" -ForegroundColor Cyan
@@ -289,10 +341,8 @@ function RestoreStartMenuFromBackup {
     Restores the start menu for the current target user from a backup.
 
     .DESCRIPTION
-    Resolves the start2.bin path for the current user (or the user specified
-    via the -User parameter), then delegates to RestoreStartMenuFromBackup.
-    Returns early with a warning if the user's start menu path cannot
-    be resolved.
+    Resolves the start2.bin path for the currently logged-in user, then
+    delegates to RestoreStartMenuFromBackup.
 
     .PARAMETER BackupFilePath
     Path to the backup file to restore from. If omitted, automatically
@@ -309,17 +359,8 @@ function RestoreStartMenu {
         [string]$BackupFilePath
     )
 
-    $targetUserName = GetUserName
-    $startMenuBinFile = GetStartMenuBinPathForUser -UserName $targetUserName
-
-    if ([string]::IsNullOrWhiteSpace($startMenuBinFile)) {
-        Write-Host "Unable to resolve start menu path for user $targetUserName, nothing to restore" -ForegroundColor Yellow
-        return [PSCustomObject]@{
-            UserName = $targetUserName
-            Result   = $false
-            Message  = "Could not resolve start menu path for user $targetUserName."
-        }
-    }
+    $targetUserName = $env:USERNAME
+    $startMenuBinFile = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin"
 
     Write-Host "Restoring start menu for user $targetUserName from backup..."
 

--- a/Scripts/Features/ReplaceStartMenu.ps1
+++ b/Scripts/Features/ReplaceStartMenu.ps1
@@ -113,11 +113,15 @@ function ReplaceStartMenu {
         return
     }
 
-    $backupBinFile = $startMenuBinFile + ".bak"
+    $timestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $backupFileName = "Win11Debloat-StartBackup-$timestamp.bak"
+    $startMenuDir = Split-Path $startMenuBinFile -Parent
+    $backupBinFile = Join-Path $startMenuDir $backupFileName
 
     if (Test-Path $startMenuBinFile) {
         # Backup current start menu file
-        Move-Item -Path $startMenuBinFile -Destination $backupBinFile -Force
+        Copy-Item -Path $startMenuBinFile -Destination $backupBinFile -Force
+        Write-Verbose "Start menu backup for user $userName saved to $backupFileName"
     }
     else {
         Write-Host "Unable to find original start2.bin file for user $userName, no backup was created for this user" -ForegroundColor Yellow
@@ -204,14 +208,14 @@ function GetStartMenuUserNameFromPath {
     The full path to the user's start2.bin file to restore.
 
     .PARAMETER BackupFilePath
-    Path to the backup file to restore from. If omitted, defaults to
-    StartMenuBinFile with a .bak extension.
+    Path to the backup file to restore from. If omitted, automatically
+    finds the latest Win11Debloat-StartBackup-*.bak file.
 
     .EXAMPLE
     RestoreStartMenuFromBackup -StartMenuBinFile "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin"
 
     .EXAMPLE
-    RestoreStartMenuFromBackup -StartMenuBinFile "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin" -BackupFilePath "C:\Backups\start2.bin"
+    RestoreStartMenuFromBackup -StartMenuBinFile "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin" -BackupFilePath "C:\Backups\Win11Debloat-StartBackup-20260101_120000.bak"
 #>
 function RestoreStartMenuFromBackup {
     param(
@@ -222,12 +226,25 @@ function RestoreStartMenuFromBackup {
 
     $userName = GetStartMenuUserNameFromPath -StartMenuBinFile $StartMenuBinFile
     $backupBinFile = if ([string]::IsNullOrWhiteSpace($BackupFilePath)) {
-        $StartMenuBinFile + '.bak'
+        # Auto-detect latest backup in the same folder as the start2.bin
+        $startMenuDir = Split-Path $StartMenuBinFile -Parent
+        $latestBackup = Get-ChildItem -Path (Join-Path $startMenuDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -First 1
+
+        if ($latestBackup) {
+            $latestBackup.FullName
+        }
+        else {
+            $StartMenuBinFile + '.bak'
+        }
     }
     else {
         $BackupFilePath
     }
-    $currentBinBackup = $StartMenuBinFile + '.restore.bak'
+    $restoreTimestamp = Get-Date -Format 'yyyyMMdd_HHmmss'
+    $restoreBackupFileName = "Win11Debloat-StartRestore-$restoreTimestamp.bak"
+    $currentBinBackup = Join-Path (Split-Path $StartMenuBinFile -Parent) $restoreBackupFileName
 
     if ($script:Params.ContainsKey("WhatIf")) {
         Write-Host "[WhatIf] Restore start menu for user $userName from backup $backupBinFile" -ForegroundColor Cyan
@@ -278,14 +295,14 @@ function RestoreStartMenuFromBackup {
     be resolved.
 
     .PARAMETER BackupFilePath
-    Path to the backup file to restore from. If omitted, defaults to
-    the .bak file alongside the current start2.bin.
+    Path to the backup file to restore from. If omitted, automatically
+    finds the latest Win11Debloat-StartBackup-*.bak file.
 
     .EXAMPLE
     RestoreStartMenu
 
     .EXAMPLE
-    RestoreStartMenu -BackupFilePath "C:\Backups\start2.bin"
+    RestoreStartMenu -BackupFilePath "C:\Backups\Win11Debloat-StartBackup-20260101_120000.bak"
 #>
 function RestoreStartMenu {
     param(
@@ -315,19 +332,21 @@ function RestoreStartMenu {
 
     .DESCRIPTION
     Iterates over every existing user profile and restores each user's
-    start2.bin from its .bak backup. For the Default user profile, removes
-    the start2.bin file (which was previously copied from a template) so
-    that new profiles revert to the system default start menu.
+    start2.bin from the latest backup in their LocalState folder. For the
+    Default user profile, removes the start2.bin file (which was previously
+    copied from a template) so that new profiles revert to the system
+    default start menu.
 
     .PARAMETER BackupFilePath
-    Path to the backup file to restore from. If omitted, defaults to
-    the .bak file alongside each user's current start2.bin.
+    Path to the backup file to restore from. If omitted, automatically
+    finds the latest Win11Debloat-StartBackup-*.bak in each user's
+    LocalState folder.
 
     .EXAMPLE
     RestoreStartMenuForAllUsers
 
     .EXAMPLE
-    RestoreStartMenuForAllUsers -BackupFilePath "C:\Backups\start2.bin"
+    RestoreStartMenuForAllUsers -BackupFilePath "C:\Backups\Win11Debloat-StartBackup-20260101_120000.bak"
 #>
 function RestoreStartMenuForAllUsers {
     param(

--- a/Scripts/Features/ReplaceStartMenu.ps1
+++ b/Scripts/Features/ReplaceStartMenu.ps1
@@ -229,7 +229,7 @@ function RestoreStartMenuFromBackup {
         # Auto-detect latest backup in the same folder as the start2.bin
         $startMenuDir = Split-Path $StartMenuBinFile -Parent
         $latestBackup = Get-ChildItem -Path (Join-Path $startMenuDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
-            Sort-Object LastWriteTime -Descending |
+            Sort-Object Name -Descending |
             Select-Object -First 1
 
         if ($latestBackup) {

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -179,7 +179,7 @@ function Show-RestoreBackupDialog {
             # CurrentUser: find the latest backup in the current user's LocalState
             $localStateDir = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
             $latestBackup = Get-ChildItem -Path (Join-Path $localStateDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
-                Sort-Object LastWriteTime -Descending |
+                Sort-Object Name -Descending |
                 Select-Object -First 1
             return @{
                 FilePath = if ($latestBackup) { $latestBackup.FullName } else { $null }

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -163,6 +163,31 @@ function Show-RestoreBackupDialog {
         & $updateStartMenuPrimaryActionText
     }
 
+    $findStartMenuAutoBackup = {
+        $scopeInfo = & $getStartMenuScopeInfo
+        if ($scopeInfo.Scope -eq 'AllUsers') {
+            # For all users, just verify at least one backup exists; per-user detection is done at restore time
+            $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
+            $usersStartMenuPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
+            foreach ($startMenuPath in $usersStartMenuPaths) {
+                $found = Get-ChildItem -Path (Join-Path $startMenuPath.FullName 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue | Select-Object -First 1
+                if ($found) { return @{ FilePath = $null; Exists = $true } }
+            }
+            return @{ FilePath = $null; Exists = $false }
+        }
+        else {
+            # CurrentUser: find the latest backup in the current user's LocalState
+            $localStateDir = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
+            $latestBackup = Get-ChildItem -Path (Join-Path $localStateDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
+                Sort-Object LastWriteTime -Descending |
+                Select-Object -First 1
+            return @{
+                FilePath = if ($latestBackup) { $latestBackup.FullName } else { $null }
+                Exists   = ($latestBackup -ne $null)
+            }
+        }
+    }
+
     $enterSelectTypeStep = {
         $titleText.Text = 'Restore Backup'
         $restoreModeTabs.SelectedIndex = 0
@@ -196,6 +221,10 @@ function Show-RestoreBackupDialog {
         $primaryActionBtn.Visibility = 'Visible'
         $primaryActionBtn.IsDefault = $true
         $chooseRegistryBtn.IsDefault = $false
+
+        # Show intro panel so user can configure scope & auto-detect
+        $startMenuAutoBackupCheck.IsChecked = $true
+        $state.SelectedStartMenuBackupFilePath = $null
         & $refreshStartMenuUi
     }
 
@@ -323,27 +352,14 @@ function Show-RestoreBackupDialog {
         }
 
         if (-not $useManualBackupFile) {
-            $autoBackupExists = $false
-            if ($scope -eq 'AllUsers') {
-                $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
-                $usersStartMenuPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
-                foreach ($startMenuPath in $usersStartMenuPaths) {
-                    if (Test-Path -LiteralPath (Join-Path $startMenuPath.FullName 'start2.bin.bak')) {
-                        $autoBackupExists = $true
-                        break
-                    }
-                }
-            }
-            else {
-                $autoBackupPath = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState\start2.bin.bak"
-                $autoBackupExists = Test-Path -LiteralPath $autoBackupPath
-            }
-
-            if (-not $autoBackupExists) {
+            $autoResult = & $findStartMenuAutoBackup
+            if (-not $autoResult.Exists) {
                 $scopeText = (& $getStartMenuScopeInfo).SummaryText
-                Show-MessageBox -Owner $window -Title 'No Backup Found' -Message "No Start Menu backup file was found. You can uncheck the 'Automatically find Start Menu backup' option to select a backup file manually." -Button 'OK' -Icon 'Warning' | Out-Null
+                Show-MessageBox -Owner $window -Title 'No Backup Found' -Message "No Start Menu backup file was found for $scopeText. Uncheck 'Automatically find' to select a backup file manually." -Button 'OK' -Icon 'Warning' | Out-Null
                 return
             }
+            # For AllUsers, FilePath is $null so per-user detection happens at restore time
+            $state.SelectedStartMenuBackupFilePath = $autoResult.FilePath
         }
 
         $window.Tag = @{
@@ -377,6 +393,7 @@ function Show-RestoreBackupDialog {
     })
 
     $startMenuScopeCombo.Add_SelectionChanged({
+        $state.SelectedStartMenuBackupFilePath = $null
         & $refreshStartMenuUi
     })
 

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -165,26 +165,23 @@ function Show-RestoreBackupDialog {
 
     $findStartMenuAutoBackup = {
         $scopeInfo = & $getStartMenuScopeInfo
+        
         if ($scopeInfo.Scope -eq 'AllUsers') {
-            # For all users, just verify at least one backup exists; per-user detection is done at restore time
             $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
             $usersStartMenuPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
             foreach ($startMenuPath in $usersStartMenuPaths) {
                 $found = Get-ChildItem -Path (Join-Path $startMenuPath.FullName 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue | Select-Object -First 1
-                if ($found) { return @{ FilePath = $null; Exists = $true } }
+                if ($found) { return $true }
             }
-            return @{ FilePath = $null; Exists = $false }
+            return $false
         }
         else {
-            # CurrentUser: find the latest backup in the current user's LocalState
             $localStateDir = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
             $latestBackup = Get-ChildItem -Path (Join-Path $localStateDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
                 Sort-Object Name -Descending |
                 Select-Object -First 1
-            return @{
-                FilePath = if ($latestBackup) { $latestBackup.FullName } else { $null }
-                Exists   = ($latestBackup -ne $null)
-            }
+
+            return ($null -ne $latestBackup)
         }
     }
 
@@ -352,14 +349,12 @@ function Show-RestoreBackupDialog {
         }
 
         if (-not $useManualBackupFile) {
-            $autoResult = & $findStartMenuAutoBackup
-            if (-not $autoResult.Exists) {
+            if (-not (& $findStartMenuAutoBackup)) {
                 $scopeText = (& $getStartMenuScopeInfo).SummaryText
                 Show-MessageBox -Owner $window -Title 'No Backup Found' -Message "No Start Menu backup file was found for $scopeText. Uncheck 'Automatically find' to select a backup file manually." -Button 'OK' -Icon 'Warning' | Out-Null
                 return
             }
-            # For AllUsers, FilePath is $null so per-user detection happens at restore time
-            $state.SelectedStartMenuBackupFilePath = $autoResult.FilePath
+            $state.SelectedStartMenuBackupFilePath = $null
         }
 
         $window.Tag = @{

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -163,28 +163,6 @@ function Show-RestoreBackupDialog {
         & $updateStartMenuPrimaryActionText
     }
 
-    $findStartMenuAutoBackup = {
-        $scopeInfo = & $getStartMenuScopeInfo
-        
-        if ($scopeInfo.Scope -eq 'AllUsers') {
-            $userPathString = GetUserDirectory -userName "*" -fileName "AppData\Local\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
-            $usersStartMenuPaths = Get-ChildItem -Path $userPathString -ErrorAction SilentlyContinue
-            foreach ($startMenuPath in $usersStartMenuPaths) {
-                $found = Get-ChildItem -Path (Join-Path $startMenuPath.FullName 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue | Select-Object -First 1
-                if ($found) { return $true }
-            }
-            return $false
-        }
-        else {
-            $localStateDir = "$env:LOCALAPPDATA\Packages\Microsoft.Windows.StartMenuExperienceHost_cw5n1h2txyewy\LocalState"
-            $latestBackup = Get-ChildItem -Path (Join-Path $localStateDir 'Win11Debloat-StartBackup-*.bak') -ErrorAction SilentlyContinue |
-                Sort-Object Name -Descending |
-                Select-Object -First 1
-
-            return ($null -ne $latestBackup)
-        }
-    }
-
     $enterSelectTypeStep = {
         $titleText.Text = 'Restore Backup'
         $restoreModeTabs.SelectedIndex = 0
@@ -349,12 +327,14 @@ function Show-RestoreBackupDialog {
         }
 
         if (-not $useManualBackupFile) {
-            if (-not (& $findStartMenuAutoBackup)) {
-                $scopeText = (& $getStartMenuScopeInfo).SummaryText
-                Show-MessageBox -Owner $window -Title 'No Backup Found' -Message "No Start Menu backup file was found for $scopeText. Uncheck 'Automatically find' to select a backup file manually." -Button 'OK' -Icon 'Warning' | Out-Null
+            $scopeInfo = & $getStartMenuScopeInfo
+            $autoBackupPath = Get-StartMenuBackupPath -Scope $scopeInfo.Scope
+            if ($null -eq $autoBackupPath) {
+                $scopeText = $scopeInfo.SummaryText
+                Show-MessageBox -Owner $window -Title 'No Backup Found' -Message "No Start Menu backup file was found for $scopeText. Uncheck 'Automatically find Start Menu backup' to select a backup file manually." -Button 'OK' -Icon 'Warning' | Out-Null
                 return
             }
-            $state.SelectedStartMenuBackupFilePath = $null
+            $state.SelectedStartMenuBackupFilePath = if ($scopeInfo.Scope -eq 'CurrentUser') { $autoBackupPath } else { $null }
         }
 
         $window.Tag = @{


### PR DESCRIPTION
This addresses #652 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Updated Start Menu backup and restore flows to use timestamped filenames stored alongside the target `start2.bin`.

- `ReplaceStartMenu.ps1` now creates `Win11Debloat-StartBackup-<yyyyMMdd_HHmmss>.bak` in the same directory as `start2.bin` by copying the current `start2.bin` to the timestamped `.bak` (instead of moving to a single fixed `.bak`), and emits the backup name via `Write-Verbose`.
- Added `Get-StartMenuBackupPath` to resolve the most recent `Win11Debloat-StartBackup-*.bak` for `CurrentUser` (directly from the current user’s LocalState) or `AllUsers` (scanning each profile’s LocalState), selecting the newest backup by descending filename.
- `RestoreStartMenuFromBackup` now auto-detects the latest `Win11Debloat-StartBackup-*.bak` in the `start2.bin` directory when `-BackupFilePath` is omitted; if no matching timestamped backup exists, the restore fails early (no legacy `.bak` fallback). The restore safety copy was updated to timestamped `Win11Debloat-StartRestore-<yyyyMMdd_HHmmss>.bak` files.
- Restore help text/examples and scope behavior were updated to reflect “latest timestamped `Win11Debloat-StartBackup-*.bak`” auto-selection, including the `RestoreStartMenuForAllUsers` guidance for restoring each user from that scope’s latest backup.
- `Scripts/GUI/Show-RestoreBackupDialog.ps1` updates the Start Menu “automatic backup” flow to use `Get-StartMenuBackupPath`: for `CurrentUser`, it selects the detected backup path; for `AllUsers`, it leaves the selected manual backup path unset. If no auto backup exists for the chosen scope, it shows a scope-specific “No Backup Found” warning (prompting the user to uncheck auto detection) and exits early; entering/changing the Start Menu scope also clears any previously selected backup file path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->