### PR TITLE
fix(startup): refuse to run under PowerShell 7 with a clear message

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -99,6 +99,17 @@ param (
     [switch]$HideDriveLetters
 )
 
+# Win11Debloat depends on Windows PowerShell 5.1 cmdlets (the Appx module's Get-AppxPackage /
+# Remove-AppxPackage, and Get-ComputerRestorePoint) that do not load in PowerShell 7 (pwsh), where the
+# Appx module fails with "Operation is not supported on this platform" (0x80131539). Without this guard
+# the run continues and silently fails to remove any apps while still reporting success. See issue #675.
+if ($PSVersionTable.PSEdition -eq 'Core') {
+    Write-Host "Win11Debloat requires Windows PowerShell 5.1, but it is running under PowerShell $($PSVersionTable.PSVersion) (pwsh / Core edition)." -ForegroundColor Red
+    Write-Host "App removal and system restore points rely on modules that are not available in PowerShell 7, so the run cannot complete correctly here." -ForegroundColor Red
+    Write-Host "Please re-run this script with Windows PowerShell instead (powershell.exe)." -ForegroundColor Yellow
+    exit 1
+}
+
 # Check if script is running as administrator
 $isAdmin = ([Security.Principal.WindowsPrincipal] `
     [Security.Principal.WindowsIdentity]::GetCurrent()


### PR DESCRIPTION
## Problem
Refs #675. Running Win11Debloat under **PowerShell 7** (pwsh) breaks: the Appx module (`Get-AppxPackage` / `Remove-AppxPackage`) fails to load with *"Operation is not supported on this platform"* (`0x80131539`), and `Get-ComputerRestorePoint` doesn't exist there. So app removal and restore points silently fail -- and the run still prints *"All changes have been applied successfully!"*, leaving the user thinking it worked when nothing was removed.

Both are Windows-PowerShell-5.1-only APIs; PS7 needs the WinPS compatibility shim (a known PowerShell limitation -- PowerShell/PowerShell#13138, #14057).

## Fix
A guard at startup, placed **before the admin check** so it also catches the already-elevated case from #675: if running under the Core edition (pwsh), print a clear message to re-run with `powershell.exe` and exit, instead of failing mid-run.

## Verification
- Parse-clean (`[Parser]::ParseFile`).
- On Windows PowerShell 5.1 (Desktop edition) the guard condition is `$false`, so it doesn't affect normal runs -- verified on `5.1.26100.8737`.
- I couldn't exercise the PS7 trigger path on my end (no pwsh session here), so worth a quick check under PowerShell 7 before merge.

## Notes
- This redirects to Windows PowerShell 5.1 rather than trying to make WD run under PS7 -- 5.1 ships in-box permanently, so redirecting is the right level of support.
- Separately (not in this PR): the *"applied successfully"* message in `Show-ApplyModal.ps1` is printed unconditionally even when removals fail -- flagged on #675 as a broader observability issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Added an early startup guard that detects when Win11Debloat is running under PowerShell 7/Core (before the admin check), prints a clear message instructing the user to rerun it with `powershell.exe`, and exits with code `1`. This prevents the script from continuing in an unsupported environment where Windows PowerShell 5.1-only APIs (e.g., `Get-AppxPackage`/`Remove-AppxPackage` and `Get-ComputerRestorePoint`) can fail or behave silently while still reporting success.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->