### PR TITLE
fix(elevation): quote script path and parameter values in admin relaunch

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -111,11 +111,7 @@ if (-not $isAdmin) {
     $choice = Read-Host "Restart as Administrator? (y/n)"
 
     if ($choice -match '^[Yy]$') {
-        # Win32-safe argument quoting for Start-Process -ArgumentList. Windows PowerShell 5.1 joins the
-        # array with spaces and does not quote, so each value is re-parsed by CommandLineToArgvW on the
-        # elevated side. Double any backslashes that precede a quote or the closing quote, escape embedded
-        # quotes, then wrap -- otherwise a value containing '"' or ending in '\' (e.g. a directory path)
-        # corrupts the relaunch command line.
+        # Win32-safe escaping for arguments to pass to elevated process
         function Format-ElevatedArg([string]$Value) {
             $escaped = $Value -replace '(\\*)"', '$1$1\"'
             $escaped = $escaped -replace '(\\+)$', '$1$1'
@@ -139,7 +135,9 @@ if (-not $isAdmin) {
         }
 
         if ($MyInvocation.UnboundArguments.Count -gt 0) {
-            $elevatedArgs += $MyInvocation.UnboundArguments
+            foreach ($unboundArg in $MyInvocation.UnboundArguments) {
+                $elevatedArgs += (Format-ElevatedArg "$unboundArg")
+            }
         }
 
         Start-Process powershell -ArgumentList $elevatedArgs -Verb RunAs

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -111,7 +111,7 @@ if (-not $isAdmin) {
     $choice = Read-Host "Restart as Administrator? (y/n)"
 
     if ($choice -match '^[Yy]$') {
-        $elevatedArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $PSCommandPath)
+        $elevatedArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"")
 
         foreach ($paramName in $PSBoundParameters.Keys) {
             $paramValue = $PSBoundParameters[$paramName]
@@ -123,7 +123,7 @@ if (-not $isAdmin) {
             }
             else {
                 $elevatedArgs += "-$paramName"
-                $elevatedArgs += "$paramValue"
+                $elevatedArgs += "`"$paramValue`""
             }
         }
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -111,7 +111,18 @@ if (-not $isAdmin) {
     $choice = Read-Host "Restart as Administrator? (y/n)"
 
     if ($choice -match '^[Yy]$') {
-        $elevatedArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "`"$PSCommandPath`"")
+        # Win32-safe argument quoting for Start-Process -ArgumentList. Windows PowerShell 5.1 joins the
+        # array with spaces and does not quote, so each value is re-parsed by CommandLineToArgvW on the
+        # elevated side. Double any backslashes that precede a quote or the closing quote, escape embedded
+        # quotes, then wrap -- otherwise a value containing '"' or ending in '\' (e.g. a directory path)
+        # corrupts the relaunch command line.
+        function Format-ElevatedArg([string]$Value) {
+            $escaped = $Value -replace '(\\*)"', '$1$1\"'
+            $escaped = $escaped -replace '(\\+)$', '$1$1'
+            return '"' + $escaped + '"'
+        }
+
+        $elevatedArgs = @("-NoProfile", "-ExecutionPolicy", "Bypass", "-File", (Format-ElevatedArg $PSCommandPath))
 
         foreach ($paramName in $PSBoundParameters.Keys) {
             $paramValue = $PSBoundParameters[$paramName]
@@ -123,7 +134,7 @@ if (-not $isAdmin) {
             }
             else {
                 $elevatedArgs += "-$paramName"
-                $elevatedArgs += "`"$paramValue`""
+                $elevatedArgs += (Format-ElevatedArg $paramValue)
             }
         }
 


### PR DESCRIPTION
## Problem
The non-admin elevation relaunch (Win11Debloat.ps1, the `if (-not $isAdmin)` block) builds `$elevatedArgs` as an **array** and passes it to `Start-Process -ArgumentList`. In Windows PowerShell 5.1 the array is joined with spaces and **not** auto-quoted, so any element containing a space is split into multiple tokens on the elevated command line:

- `-File $PSCommandPath` -- if the script lives under a spaced path (e.g. extracted to `C:\Program Files\...`), the elevated process gets `-File C:\Program` and cannot find the script at all.
- Any string parameter value with a space -- e.g. `-Config "C:\Program Files\my config.json"`, `-User "John Doe"`, `-ReplaceStart "C:\Layouts\start menu.json"`, `-LogPath "C:\Log Files"` -- the elevated instance binds the parameter to the first token only (`-Config` -> `C:\Program`) and treats the rest as unbound args. `ImportConfigToParams` then throws "Unable to find config file", or the wrong user/start-menu path is targeted.

Switch parameters are unaffected (handled separately). The sibling launcher `Scripts/Get.ps1` already quotes both the script path and values (`-File "..."` and `"-$($_.Key) ""$($_.Value)"""`) -- this is the same contract the main script's array form omits.

## Fix
Quote the script path and the string parameter values when building `$elevatedArgs`, so spaced values survive intact through `Start-Process -ArgumentList`.

## Verification
- Parse-clean (`[Parser]::ParseFile`).
- Reproduced the **fixed** behavior non-destructively on Windows PowerShell 5.1 (5.1.26100.8737): built the array exactly as the code does (with the quoting) and called `Start-Process powershell -ArgumentList $elevatedArgs` against a probe script that echoes its bound params (no `-Verb RunAs`, so no UAC / no system change). The child correctly bound `-Config = C:\Program Files\my config.json` and `-User = John Doe`, both intact. Without the quoting the same harness splits them.
- I did **not** run the full elevated (`-Verb RunAs`/UAC) path end-to-end -- worth a quick check there before merge, though the argument construction is what matters and it round-trips correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed the non-admin elevation relaunch in `Win11Debloat.ps1` by introducing a Win32-safe `Format-ElevatedArg` helper that wraps and escapes argument values using `Start-Process -ArgumentList` (including quoting the `-File` script path via `$PSCommandPath`). It now formats bound, non-switch parameter values (e.g., `-Config`, `-User`, `-ReplaceStart`, `-LogPath`) before appending them to `$elevatedArgs`, and also Win32-escapes any `$MyInvocation.UnboundArguments`, preventing PowerShell 5.1 from splitting/garbling values containing spaces or special characters (notably trailing backslashes like `C:\Log Files\` and embedded quotes). Switch parameters are still passed through unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->