### PR TITLE
fix(store-search): correct EVERYONE deny-ACE detection in undo path

### DIFF
--- a/Scripts/Features/StoreSearchSuggestions.ps1
+++ b/Scripts/Features/StoreSearchSuggestions.ps1
@@ -158,9 +158,14 @@ function EnableStoreSearchSuggestions {
         $acl = Get-Acl -Path $StoreAppsDatabase
         $denyRules = @(
             $acl.Access | Where-Object {
-                $_.AccessControlType -eq [System.Security.AccessControl.AccessControlType]::Deny -and
-                (($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -ne 0) -and
-                (try { $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]) -eq $everyoneSid } catch { $false })
+                if ($_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Deny) { return $false }
+                if (($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq 0) { return $false }
+                try {
+                    return ($_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]) -eq $everyoneSid)
+                }
+                catch {
+                    return $false
+                }
             }
         )
 


### PR DESCRIPTION
Fixes a Windows PowerShell 5.1 bug in the DisableStoreSearchSuggestions undo path (EnableStoreSearchSuggestions). The filter that finds the EVERYONE Deny FullControl ACE to strip used an inline (try {...} catch {...}) as a boolean sub-expression inside Where-Object. In PS 5.1 'try' is a statement, not an expression, so at runtime it is parsed as a command invocation and throws CommandNotFoundException. The throw is swallowed by the surrounding try/catch, so the whole ACL-normalization block is skipped on EVERY undo run: the EVERYONE Deny FullControl ACE is never removed via Set-Acl, and a misleading 'Failed to normalize ACL' warning prints each time. The undo only succeeds incidentally because the store database file is deleted afterwards. Fix: replace the inline try-expression with statement-form guards and a real try/catch. Verification: parse-clean; tested the rewritten filter in-memory on PS 5.1.26100.8737 against a constructed ACL (EVERYONE Deny FullControl plus non-matching rules) - it throws nothing and returns exactly the EVERYONE Deny rule, while the original inline-try form throws CommandNotFoundException on the same input. No file, registry, or ACL on the system was modified by the test. I did not run the full GUI disable-then-undo flow end-to-end live.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed the `EnableStoreSearchSuggestions` undo path on Windows PowerShell 5.1 by correcting the `Where-Object` filter used to remove the “EVERYONE” Deny FullControl ACE. The previous implementation used an inline `try { ... } catch { ... }` inside a boolean expression, which is invalid in PowerShell 5.1 and led to a `CommandNotFoundException`; the surrounding `try/catch` then skipped the ACL normalization step, producing the misleading “Failed to normalize ACL” warning and preventing the deny ACE from being removed via `Set-Acl`.

The filter was rewritten to use statement-form guards and a proper `try/catch`, now:
- checks for `Deny` rules
- verifies `FullControl` rights
- safely translates `IdentityReference` to a `SecurityIdentifier`
- matches against the cached `EVERYONE` SID (`S-1-1-0`)
- returns `false` when translation fails
<!-- end of auto-generated comment: release notes by coderabbit.ai -->