### PR TITLE
fix(restore-gui): surface registry-backup load failures to the user

### DIFF
--- a/Scripts/Features/RestoreRegistryBackup.ps1
+++ b/Scripts/Features/RestoreRegistryBackup.ps1
@@ -1,3 +1,19 @@
+<#
+    .SYNOPSIS
+        Loads a registry backup from a JSON file and normalizes its contents.
+
+    .DESCRIPTION
+        Loads a registry backup from disk and returns a normalized representation
+        of its contents suitable for use by the restore workflow. Throws if the
+        file is missing, unreadable, or not valid JSON.
+
+    .PARAMETER FilePath
+        The absolute path to the registry backup JSON file to load.
+
+    .OUTPUTS
+        PSCustomObject
+        A normalized registry backup object produced by Normalize-RegistryBackup.
+#>
 function Load-RegistryBackupFromFile {
     param(
         [Parameter(Mandatory)]
@@ -18,6 +34,24 @@ function Load-RegistryBackupFromFile {
     return Normalize-RegistryBackup -Backup $rawBackup
 }
 
+<#
+    .SYNOPSIS
+        Validates and normalizes a raw registry backup object.
+
+    .DESCRIPTION
+        Validates the structure and content of the supplied backup and converts
+        it into a normalized representation that can be safely consumed by the
+        restore workflow. Throws if validation fails.
+
+    .PARAMETER Backup
+        The raw backup object (typically parsed from JSON) to normalize.
+
+    .OUTPUTS
+        PSCustomObject
+        A normalized backup with Version, BackupType, CreatedAt, CreatedBy,
+        ComputerName, Target, SelectedFeatures, SelectedUndoFeatures, and
+        RegistryKeys properties.
+#>
 function Normalize-RegistryBackup {
     param(
         [Parameter(Mandatory)]
@@ -132,6 +166,23 @@ function Normalize-RegistryBackup {
     }
 }
 
+<#
+    .SYNOPSIS
+        Restores registry state from a normalized backup object.
+
+    .DESCRIPTION
+        Applies the registry state described by the supplied backup back to the
+        registry, loading the appropriate user hive when required.
+
+    .PARAMETER Backup
+        A normalized backup object (as produced by Normalize-RegistryBackup) whose
+        RegistryKeys snapshots should be restored.
+
+    .OUTPUTS
+        PSCustomObject
+        Returns an object with a Result property set to $true when the restore
+        completes successfully.
+#>
 function Restore-RegistryBackupState {
     param(
         [Parameter(Mandatory)]

--- a/Scripts/Features/RestoreRegistryBackup.ps1
+++ b/Scripts/Features/RestoreRegistryBackup.ps1
@@ -97,9 +97,16 @@ function Normalize-RegistryBackup {
     if ($allSelectedFeatures.Count -eq 0) {
         $errors.Add('Backup must contain at least one feature ID in SelectedFeatures or SelectedUndoFeatures.')
     }
-    $allowListValidationErrors = @(Test-RegistryBackupMatchesSelectedFeatures -SelectedFeatureIds @($selectedFeatures) -SelectedUndoFeatureIds @($selectedUndoFeatures) -Target $normalizedTarget -RegistryKeys @($normalizedKeys))
-    foreach ($allowListValidationError in $allowListValidationErrors) {
-        $errors.Add([string]$allowListValidationError)
+    else {
+        try {
+            $allowListValidationErrors = @(Test-RegistryBackupMatchesSelectedFeatures -SelectedFeatureIds @($selectedFeatures) -SelectedUndoFeatureIds @($selectedUndoFeatures) -Target $normalizedTarget -RegistryKeys @($normalizedKeys))
+            foreach ($allowListValidationError in $allowListValidationErrors) {
+                $errors.Add([string]$allowListValidationError)
+            }
+        }
+        catch {
+            $errors.Add("Failed to validate backup: $($_.Exception.Message)")
+        }
     }
 
     if ($errors.Count -gt 0) {

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -295,9 +295,19 @@ function Show-RestoreBackupDialog {
         }
 
         Write-Host "Backup file selected: $($openDialog.FileName)"
-        $selectedBackup = Load-RegistryBackupFromFile -FilePath $openDialog.FileName
 
-        if (-not (& $showRegistryOverview -SelectedBackup $selectedBackup -SelectedBackupFilePath $openDialog.FileName)) {
+        try {
+            $selectedBackup = Load-RegistryBackupFromFile -FilePath $openDialog.FileName
+
+            if (-not (& $showRegistryOverview -SelectedBackup $selectedBackup -SelectedBackupFilePath $openDialog.FileName)) {
+                return
+            }
+        }
+        catch {
+            # Surface load/validation failures to the user. Without this, the throw escapes the
+            # button-click handler, is caught only by the dispatcher's global unhandled-exception
+            # handler (which merely writes a console warning), and the dialog silently does nothing.
+            Show-MessageBox -Owner $window -Title 'Invalid Backup File' -Message "The selected file could not be loaded as a registry backup:`n`n$($_.Exception.Message)" -Button 'OK' -Icon 'Error' | Out-Null
             return
         }
 

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -304,10 +304,7 @@ function Show-RestoreBackupDialog {
             }
         }
         catch {
-            # Surface load/validation failures to the user. Without this, the throw escapes the
-            # button-click handler, is caught only by the dispatcher's global unhandled-exception
-            # handler (which merely writes a console warning), and the dialog silently does nothing.
-            Show-MessageBox -Owner $window -Title 'Invalid Backup File' -Message "The selected file could not be loaded as a registry backup:`n`n$($_.Exception.Message)" -Button 'OK' -Icon 'Error' | Out-Null
+            Show-MessageBox -Owner $window -Title 'Invalid Backup File' -Message "The selected file could not be loaded:`n$($_.Exception.Message)" -Button 'OK' -Icon 'Error' | Out-Null
             return
         }
 

--- a/Scripts/GUI/Show-RestoreBackupDialog.ps1
+++ b/Scripts/GUI/Show-RestoreBackupDialog.ps1
@@ -1,3 +1,24 @@
+<#
+    .SYNOPSIS
+        Displays the Restore Backup wizard dialog.
+
+    .DESCRIPTION
+        Presents a modal wizard that lets the user choose and restore either a
+        registry backup or a Start Menu pinned-apps backup. Returns the user's 
+        selection via $window.Tag.
+
+    .PARAMETER Owner
+        Optional parent WPF Window used to host this modal dialog. Defaults to the
+        shared $script:GuiWindow when not supplied.
+
+    .OUTPUTS
+        Hashtable
+        Returns a Hashtable describing the user's choice. Possible shapes:
+          RestoreRegistry  - @{ Result='RestoreRegistry'; Backup=<normalizedBackup> }
+          RestoreStartMenu - @{ Result='RestoreStartMenu'; StartMenuScope=<scope>;
+                               UseManualBackupFile=<bool>; BackupFilePath=<path|string> }
+          Cancelled        - @{ Result='Cancelled' } (from New-RestoreDialogState)
+#>
 function Show-RestoreBackupDialog {
     param(
         [System.Windows.Window]$Owner = $null


### PR DESCRIPTION
Picking a malformed or invalid registry backup .json in the Restore Backup dialog throws out of the WPF button-click handler (Load-RegistryBackupFromFile throws on bad JSON or schema-validation failure; the overview render throws on a backup with no restorable changes). Because the throw originates inside a WPF dispatcher callback, it bypasses every surrounding try/catch -- the dialog's own ShowDialog try/catch and Show-RestoreBackupWindow's try/catch both sit on a different call stack than the dispatcher-invoked click handler -- and is caught only by Show-MainWindow's global Dispatcher.UnhandledException handler, which only writes a console warning (invisible in a windowed GUI) and sets Handled=true. Net effect: the user picks a bad file and the dialog silently does nothing -- no error, no feedback, it just sits there. This is the most-reachable restore failure: one wrong pick in the file-open dialog (a non-backup json, a truncated download, a backup for another machine). FIX: wrap the load + overview render in try/catch and surface the failure via the existing Show-MessageBox helper -- the same pattern already used elsewhere in this file. The dialog stays open so the user can pick a different file. VERIFICATION: parse-clean; the Show-MessageBox call matches the existing usage signature in this file (-Owner -Title -Message -Button OK -Icon). I did not launch the full WPF GUI end-to-end this session; the change is a localized try/catch around the two throwing calls using the file's own error-dialog helper. Cross-checked against Microsoft's documented Dispatcher.UnhandledException interception-before-ShowDialog-try/catch behavior, so the wrapping is inside the click handler where it can actually catch the throw.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This change makes restore-backup failures visible to users instead of failing silently in the WPF restore dialog.

- Wraps backup loading and registry overview rendering/initialization in a local `try/catch` in `Show-RestoreBackupDialog.ps1` (so exceptions don’t escape the click handler)
- Shows an “Invalid Backup File” message via the existing `Show-MessageBox` helper, including `($_.Exception.Message)`, and keeps the dialog open so the user can choose another backup file
- Updates `Normalize-RegistryBackup` to wrap allow-list validation in a `try/catch`, appending `Failed to validate backup: <exception message>` to `$errors` so runtime validation exceptions are captured and then handled by the existing aggregation/throw logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->