### PR TITLE
Fix broken contributing link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Below is an overview of the key features and functionality offered by Win11Deblo
 
 ## Contributing
 
-We welcome contributions of all kinds! Please see our [Contributing Guidelines](https://github.com/Raphire/Win11Debloat/blob/main/.github/CONTRIBUTING.md) for detailed instructions on how to get started and best practices for contributing.
+We welcome contributions of all kinds! Please see our [Contributing Guidelines](https://github.com/Raphire/Win11Debloat/blob/master/.github/CONTRIBUTING.md) for detailed instructions on how to get started and best practices for contributing.
 
 ## License
 


### PR DESCRIPTION
Fixes the broken contributing guidelines link in README.md by pointing it to the master branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Updated the README’s Contributing section link to point to the `master` branch so the `CONTRIBUTING.md` page resolves correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->