### PR TITLE
Fix issues with domain accounts & fix run.bat breaking when launched from path with certain characters

### DIFF
--- a/Run.bat
+++ b/Run.bat
@@ -19,17 +19,17 @@ if exist "%wtDefaultPath%" (
     set "wtPath="
 )
 
-set "SCRIPT_PATH=\"%~dp0Win11Debloat.ps1\""
+set "SCRIPT_PATH=%~dp0Win11Debloat.ps1"
 
 :: Launch script
 if defined wtPath (
     call :Log Launching Win11Debloat.ps1 with Windows Terminal...
-    PowerShell -Command "Start-Process -FilePath '%wtPath%' -ArgumentList 'PowerShell -NoProfile -ExecutionPolicy Bypass -File %SCRIPT_PATH%' -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; Start-Process -FilePath '%wtPath%' -ArgumentList @('PowerShell','-NoProfile','-ExecutionPolicy','Bypass','-File',$p) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
     call :Log Script execution passed successfully to Win11Debloat.ps1
 ) else (
     echo Windows Terminal not found. Using default PowerShell instead...
     call :Log Windows Terminal not found. Using default PowerShell to launch Win11Debloat.ps1...
-    PowerShell -ExecutionPolicy Bypass -Command "& {Start-Process PowerShell -ArgumentList '-NoProfile -ExecutionPolicy Bypass -File %SCRIPT_PATH%' -Verb RunAs}" >> "%logFile%" || call :Error "PowerShell command failed"
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; Start-Process PowerShell -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File',$p) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
     call :Log Script execution passed successfully to Win11Debloat.ps1
 )
 

--- a/Run.bat
+++ b/Run.bat
@@ -24,12 +24,12 @@ set "SCRIPT_PATH=%~dp0Win11Debloat.ps1"
 :: Launch script
 if defined wtPath (
     call :Log Launching Win11Debloat.ps1 with Windows Terminal...
-    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; Start-Process -FilePath '%wtPath%' -ArgumentList @('PowerShell','-NoProfile','-ExecutionPolicy','Bypass','-File',$p) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; $q=[char]34; Start-Process -FilePath '%wtPath%' -ArgumentList ('PowerShell -NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
     call :Log Script execution passed successfully to Win11Debloat.ps1
 ) else (
     echo Windows Terminal not found. Using default PowerShell instead...
     call :Log Windows Terminal not found. Using default PowerShell to launch Win11Debloat.ps1...
-    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; Start-Process PowerShell -ArgumentList @('-NoProfile','-ExecutionPolicy','Bypass','-File',$p) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; $q=[char]34; Start-Process PowerShell -ArgumentList ('-NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
     call :Log Script execution passed successfully to Win11Debloat.ps1
 )
 

--- a/Run.bat
+++ b/Run.bat
@@ -1,5 +1,5 @@
 @echo off
-setlocal EnableDelayedExpansion
+setlocal
 
 :: Set Windows Terminal installation paths. (Default and Scoop installation)
 set "wtDefaultPath=%LOCALAPPDATA%\Microsoft\WindowsApps\wt.exe"
@@ -15,22 +15,20 @@ if exist "%wtDefaultPath%" (
 ) else if exist "%wtScoopPath%" (
     set "wtPath=%wtScoopPath%"
 ) else (
-    echo Windows Terminal not found. Using default PowerShell instead.
     set "wtPath="
 )
 
+:: Interpolated into a PS single-quoted string below;
+:: Apostrophes escaped via %:'=''% and -File arg uses [char]34 to avoid quote-parity bugs.
 set "SCRIPT_PATH=%~dp0Win11Debloat.ps1"
 
-:: Launch script
 if defined wtPath (
     call :Log Launching Win11Debloat.ps1 with Windows Terminal...
-    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; $q=[char]34; Start-Process -FilePath '%wtPath%' -ArgumentList ('PowerShell -NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
-    call :Log Script execution passed successfully to Win11Debloat.ps1
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH:'=''%'; $q=[char]34; Start-Process -FilePath '%wtPath%' -ArgumentList ('PowerShell -NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
 ) else (
-    echo Windows Terminal not found. Using default PowerShell instead...
+    echo Windows Terminal not found, using default PowerShell...
     call :Log Windows Terminal not found. Using default PowerShell to launch Win11Debloat.ps1...
-    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH%'; $q=[char]34; Start-Process PowerShell -ArgumentList ('-NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
-    call :Log Script execution passed successfully to Win11Debloat.ps1
+    PowerShell -NoProfile -ExecutionPolicy Bypass -Command "$p='%SCRIPT_PATH:'=''%'; $q=[char]34; Start-Process PowerShell -ArgumentList ('-NoProfile -ExecutionPolicy Bypass -File ' + $q + $p + $q) -Verb RunAs" >> "%logFile%" || call :Error "PowerShell command failed"
 )
 
 echo.
@@ -40,11 +38,13 @@ goto :EOF
 
 :: Logging Function
 :Log
-echo %* >> "%logFile%"
+echo(%* >> "%logFile%"
 goto :EOF
+
 :: Error Handler
 :Error
-echo ERROR: %*
+echo(ERROR: %*
+call :Log ERROR: %*
 echo Logged in %logFile%
 pause
 goto :EOF

--- a/Scripts/Features/RestoreRegistryBackup.ps1
+++ b/Scripts/Features/RestoreRegistryBackup.ps1
@@ -93,7 +93,8 @@ function Normalize-RegistryBackup {
         }
         elseif ($normalizedTarget -like 'CurrentUser:*') {
             $targetCurrentUserName = $normalizedTarget.Substring(12)
-            if ([string]::IsNullOrWhiteSpace($targetCurrentUserName) -or ($targetCurrentUserName -ne $env:USERNAME)) {
+            if ([string]::IsNullOrWhiteSpace($targetCurrentUserName) -or
+                -not (Test-UserNameMatch -UserNameA $targetCurrentUserName -UserNameB $env:USERNAME)) {
                  $errors.Add("Backup was made for '$targetCurrentUserName', this does not match current user '$env:USERNAME'.")
             }
         }

--- a/Scripts/Helpers/ResolveUserProfilePath.ps1
+++ b/Scripts/Helpers/ResolveUserProfilePath.ps1
@@ -1,3 +1,19 @@
+<#
+    .SYNOPSIS
+        Normalize a user-name string for lookup and comparison.
+
+    .DESCRIPTION
+        User input can carry zero-width characters or stray whitespace that
+        would silently break lookups and matches. Normalizing once up front
+        keeps every downstream comparison robust against purely cosmetic
+        differences. Returns an empty string for blank input.
+
+    .PARAMETER Value
+        Raw user-supplied name to normalize.
+
+    .OUTPUTS
+        System.String
+#>
 function NormalizeUserLookupValue {
     param(
         [string]$Value
@@ -7,7 +23,6 @@ function NormalizeUserLookupValue {
         return ''
     }
 
-    # Remove zero-width characters and normalize whitespace for robust comparisons.
     $normalized = $Value -replace '[\u200B-\u200D\uFEFF]', ''
     $normalized = $normalized.Trim() -replace '\s+', ' '
     return $normalized
@@ -17,6 +32,23 @@ if (-not $script:ResolvedUserSidCache) {
     $script:ResolvedUserSidCache = @{}
 }
 
+<#
+    .SYNOPSIS
+        Build a form-agnostic cache key for a user name.
+
+    .DESCRIPTION
+        SID resolution is expensive and called repeatedly for the same identity,
+        so the cache must be keyed by something that survives cosmetic input
+        differences. Normalizing and lower-casing ensures the same identity hits
+        regardless of case, whitespace, or qualifier form. Returns an empty
+        string for blank input.
+
+    .PARAMETER Value
+        User name to derive a key from.
+
+    .OUTPUTS
+        System.String
+#>
 function GetUserLookupCacheKey {
     param(
         [string]$Value
@@ -30,6 +62,21 @@ function GetUserLookupCacheKey {
     return $normalizedValue.ToLowerInvariant()
 }
 
+<#
+    .SYNOPSIS
+        Escape a string for safe embedding in a WQL single-quoted literal.
+
+    .DESCRIPTION
+        WQL string literals are single-quoted, so any embedded quote must be
+        doubled. Without this, a user-supplied name containing an apostrophe
+        could break the filter or enable WQL injection.
+
+    .PARAMETER Value
+        String to escape.
+
+    .OUTPUTS
+        System.String
+#>
 function EscapeWqlString {
     param(
         [string]$Value
@@ -42,6 +89,22 @@ function EscapeWqlString {
     return $Value -replace "'", "''"
 }
 
+<#
+    .SYNOPSIS
+        Extract the local name segment from a possibly domain-qualified identity.
+
+    .DESCRIPTION
+        Profile folder leafs never carry the domain prefix, so qualified
+        identities (DOMAIN\user, user@domain) must be reduced to the local
+        segment before any on-disk comparison can succeed. Returns an empty
+        string for blank input.
+
+    .PARAMETER UserName
+        User name that may be domain-qualified.
+
+    .OUTPUTS
+        System.String
+#>
 function GetLocalUserNameSegment {
     param(
         [string]$UserName
@@ -63,6 +126,271 @@ function GetLocalUserNameSegment {
     return $normalizedName
 }
 
+<#
+    .SYNOPSIS
+        Determine whether the local machine is joined to a domain.
+
+    .DESCRIPTION
+        Domain vs. workgroup selects entirely different matching rules
+        (suffix-aware vs. strict legacy), so every downstream decision needs
+        one cheap, consistent answer. Cached in script scope to avoid repeated
+        CIM round-trips. The cache is valid only for the current process
+        lifetime; joining/unjoining while the script runs is not supported.
+        Returns $false on any error or on workgroup machines, so callers
+        safely fall back to legacy matching.
+
+    .OUTPUTS
+        System.Boolean
+#>
+function Test-MachineIsDomainJoined {
+    if ($null -ne $script:MachineDomainJoinStateKnown) {
+        return [bool]$script:MachineIsDomainJoined
+    }
+
+    $script:MachineDomainJoinStateKnown = $true
+    $script:MachineIsDomainJoined = $false
+    $script:MachineNetBiosDomain = ''
+
+    try {
+        $computerSystem = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
+        if ($null -ne $computerSystem -and $computerSystem.PartOfDomain) {
+            $script:MachineIsDomainJoined = $true
+            $script:MachineNetBiosDomain = [string]$computerSystem.Domain
+        }
+    }
+    catch {
+        # Leave as $false; callers fall back to legacy matching.
+    }
+
+    return [bool]$script:MachineIsDomainJoined
+}
+
+<#
+    .SYNOPSIS
+        Return the NetBIOS domain suffix Windows appends to profile folders.
+
+    .DESCRIPTION
+        On domain-joined machines Windows writes profile folders as
+        user.CONTOSO; knowing the suffix lets a bare user name match that
+        folder. Workgroup USERDOMAIN is just the computer name and would
+        produce false matches, so it is excluded. Falls back to the NetBIOS
+        domain captured by Test-MachineIsDomainJoined when USERDOMAIN is
+        empty in restricted execution contexts.
+
+    .OUTPUTS
+        System.String
+#>
+function GetProfileFolderDomainSuffix {
+    if (-not (Test-MachineIsDomainJoined)) {
+        return ''
+    }
+
+    $domain = $env:USERDOMAIN
+    if ([string]::IsNullOrWhiteSpace($domain)) {
+        # Some restricted execution contexts leave USERDOMAIN empty even when
+        # joined; the value captured by the Win32_ComputerSystem query is the
+        # reliable alternative.
+        $domain = $script:MachineNetBiosDomain
+    }
+    if ([string]::IsNullOrWhiteSpace($domain)) {
+        return ''
+    }
+
+    # USERDOMAIN == COMPUTERNAME means the box is effectively standalone; a
+    # suffix here would produce false matches instead of disambiguation.
+    if ($domain -ieq $env:COMPUTERNAME) {
+        return ''
+    }
+
+    return $domain.Trim()
+}
+
+<#
+    .SYNOPSIS
+        Enumerate the name forms equivalent to a given identity.
+
+    .DESCRIPTION
+        One identity surfaces in different forms depending on where it was
+        captured (bare, qualified, domain-suffixed). Enumerating every
+        equivalent form lets cross-source matching succeed without broadening
+        workgroup validation. Duplicates are removed. Returns an empty array
+        for blank input.
+
+    .PARAMETER Value
+        User name to expand into equivalent forms.
+
+    .OUTPUTS
+        System.String[]
+#>
+function GetUserNameMatchCandidates {
+    param(
+        [string]$Value
+    )
+
+    $normalized = NormalizeUserLookupValue -Value $Value
+    if ([string]::IsNullOrWhiteSpace($normalized)) {
+        return @()
+    }
+
+    $candidates = New-Object 'System.Collections.Generic.List[string]'
+    [void]$candidates.Add($normalized)
+
+    $localSegment = GetLocalUserNameSegment -UserName $normalized
+    if (-not [string]::IsNullOrWhiteSpace($localSegment) -and ($localSegment -ine $normalized)) {
+        [void]$candidates.Add($localSegment)
+    }
+
+    # Domain-suffixed forms only make sense where Windows actually writes them.
+    $domainSuffix = GetProfileFolderDomainSuffix
+    if (-not [string]::IsNullOrWhiteSpace($domainSuffix)) {
+        # The base the suffix extends: prefer the local segment so qualified
+        # identities (DOMAIN\user) still produce user.CONTOSO rather than the
+        # fully qualified string.
+        $stem = if (-not [string]::IsNullOrWhiteSpace($localSegment)) { $localSegment } else { $normalized }
+        if (-not [string]::IsNullOrWhiteSpace($stem)) {
+            $suffixedForm = "$stem.$domainSuffix"
+            $alreadyPresent = $false
+            foreach ($existing in $candidates) {
+                if ($existing -ieq $suffixedForm) { $alreadyPresent = $true; break }
+            }
+            if (-not $alreadyPresent) {
+                [void]$candidates.Add($suffixedForm)
+            }
+        }
+
+        # A suffixed input can also be referenced by its bare stem elsewhere
+        # (registry, backup metadata), so add that form too.
+        $suffixWithDot = ".$domainSuffix"
+        if ($normalized.Length -gt $suffixWithDot.Length -and $normalized.EndsWith($suffixWithDot, [System.StringComparison]::OrdinalIgnoreCase)) {
+            $bareStem = NormalizeUserLookupValue -Value ($normalized.Substring(0, $normalized.Length - $suffixWithDot.Length))
+            if (-not [string]::IsNullOrWhiteSpace($bareStem)) {
+                $alreadyPresent = $false
+                foreach ($existing in $candidates) {
+                    if ($existing -ieq $bareStem) { $alreadyPresent = $true; break }
+                }
+                if (-not $alreadyPresent) {
+                    [void]$candidates.Add($bareStem)
+                }
+            }
+        }
+    }
+
+    return $candidates.ToArray() | Select-Object -Unique
+}
+
+<#
+    .SYNOPSIS
+        Test whether a user name and a profile folder leaf share an account.
+
+    .DESCRIPTION
+        A profile leaf and a user input may describe the same account in
+        different forms; comparing candidate sets instead of raw strings
+        tolerates that. Domain-joined machines also accept suffixed forms via
+        GetUserNameMatchCandidates.
+
+    .PARAMETER UserName
+        User-supplied name to compare.
+
+    .PARAMETER ProfileLeaf
+        On-disk profile folder leaf name to compare.
+
+    .OUTPUTS
+        System.Boolean
+#>
+function Test-UserNameMatchesProfileLeaf {
+    param(
+        [string]$UserName,
+        [string]$ProfileLeaf
+    )
+
+    if ([string]::IsNullOrWhiteSpace($UserName) -or [string]::IsNullOrWhiteSpace($ProfileLeaf)) {
+        return $false
+    }
+
+    $leafCandidates = @(GetUserNameMatchCandidates -Value $ProfileLeaf)
+    $userCandidates = @(GetUserNameMatchCandidates -Value $UserName)
+
+    foreach ($leaf in $leafCandidates) {
+        foreach ($user in $userCandidates) {
+            if ($leaf -ieq $user) {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+<#
+    .SYNOPSIS
+        Test whether two user-name strings refer to the same account.
+
+    .DESCRIPTION
+        Backups record whatever name the running session reported, which may
+        not match the restore session's form. Accepting any equivalent
+        candidate makes restore work across sessions and machine join states.
+        Workgroup stays a strict normalized equality check to avoid broadening
+        validation where suffixes aren't meaningful.
+
+    .PARAMETER UserNameA
+        First user name to compare.
+
+    .PARAMETER UserNameB
+        Second user name to compare.
+
+    .OUTPUTS
+        System.Boolean
+#>
+function Test-UserNameMatch {
+    param(
+        [string]$UserNameA,
+        [string]$UserNameB
+    )
+
+    if ([string]::IsNullOrWhiteSpace($UserNameA) -and [string]::IsNullOrWhiteSpace($UserNameB)) {
+        return $true
+    }
+    if ([string]::IsNullOrWhiteSpace($UserNameA) -or [string]::IsNullOrWhiteSpace($UserNameB)) {
+        return $false
+    }
+
+    # Keep workgroup strict to avoid silently broadening restore scope where no
+    # suffix disambiguation exists to justify it.
+    if (-not (Test-MachineIsDomainJoined)) {
+        $normalizedA = NormalizeUserLookupValue -Value $UserNameA
+        $normalizedB = NormalizeUserLookupValue -Value $UserNameB
+        return ($normalizedA -ieq $normalizedB)
+    }
+
+    $candidatesA = @(GetUserNameMatchCandidates -Value $UserNameA)
+    $candidatesB = @(GetUserNameMatchCandidates -Value $UserNameB)
+
+    foreach ($a in $candidatesA) {
+        foreach ($b in $candidatesB) {
+            if ($a -ieq $b) {
+                return $true
+            }
+        }
+    }
+
+    return $false
+}
+
+<#
+    .SYNOPSIS
+        Memoize a resolved SID under every equivalent name form.
+
+    .DESCRIPTION
+        SID resolution is expensive and called repeatedly for the same user.
+        Memoizing under every equivalent form means later lookups short-circuit
+        regardless of which variant the caller has in hand. No-op on blank SID.
+
+    .PARAMETER Candidates
+        Equivalent name forms to key the cache entry under.
+
+    .PARAMETER Sid
+        Resolved SID to cache.
+#>
 function SetResolvedUserSidCache {
     param(
         [string[]]$Candidates,
@@ -81,6 +409,21 @@ function SetResolvedUserSidCache {
     }
 }
 
+<#
+    .SYNOPSIS
+        Retrieve a previously cached resolved SID.
+
+    .DESCRIPTION
+        Companion to SetResolvedUserSidCache. Checks every equivalent form
+        because the caller may only hold one of them, but a prior resolution
+        under a different form should still hit. Returns $null on a miss.
+
+    .PARAMETER Candidates
+        Equivalent name forms to probe the cache with.
+
+    .OUTPUTS
+        System.String
+#>
 function GetCachedResolvedUserSid {
     param(
         [string[]]$Candidates
@@ -96,6 +439,22 @@ function GetCachedResolvedUserSid {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Attempt SID resolution via NTAccount translation.
+
+    .DESCRIPTION
+        NTAccount.Translate is the most authoritative SID source, but only
+        resolves when the name is reachable through standard security APIs.
+        Failures fall through to cheaper, broader heuristics in the caller.
+        Returns $null on failure.
+
+    .PARAMETER UserName
+        Name to translate.
+
+    .OUTPUTS
+        System.String
+#>
 function TryResolveSidByNtAccount {
     param(
         [string]$UserName
@@ -119,6 +478,22 @@ function TryResolveSidByNtAccount {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Attempt SID resolution against the local account database.
+
+    .DESCRIPTION
+        Local SAM and Win32_UserAccount are ground truth for local accounts.
+        Prefers Get-LocalUser (typed, fast) and falls back to CIM for older
+        hosts or contexts where the cmdlet is unavailable. Returns $null when
+        no candidate resolves.
+
+    .PARAMETER Candidates
+        Equivalent name forms to try.
+
+    .OUTPUTS
+        System.String
+#>
 function TryResolveSidByLocalLookup {
     param(
         [string[]]$Candidates
@@ -162,6 +537,22 @@ function TryResolveSidByLocalLookup {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Recover a SID from the ProfileList registry hive.
+
+    .DESCRIPTION
+        Last-resort heuristic: when name-resolution APIs fail, the ProfileList
+        hive still links SIDs to on-disk profile folders, so matching the
+        folder leaf can recover a SID that no other source would surface.
+        Returns $null on failure.
+
+    .PARAMETER Candidates
+        Equivalent name forms to match against profile folder leafs.
+
+    .OUTPUTS
+        System.String
+#>
 function TryResolveSidFromProfileList {
     param(
         [string[]]$Candidates
@@ -183,7 +574,12 @@ function TryResolveSidFromProfileList {
                 $leafName = NormalizeUserLookupValue -Value (Split-Path -Leaf $expandedPath)
 
                 foreach ($candidate in $lookupCandidates) {
-                    if ($leafName -ieq $candidate) {
+                    if (Test-MachineIsDomainJoined) {
+                        if (Test-UserNameMatchesProfileLeaf -UserName $candidate -ProfileLeaf $leafName) {
+                            return $sidKey.PSChildName
+                        }
+                    }
+                    elseif ($leafName -ieq $candidate) {
                         return $sidKey.PSChildName
                     }
                 }
@@ -200,6 +596,27 @@ function TryResolveSidFromProfileList {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Construct a resolved user context object.
+
+    .DESCRIPTION
+        Bundles the resolved fields so callers don't re-derive their
+        relationship downstream or thread three loose values through every
+        call site.
+
+    .PARAMETER UserName
+        Normalized user name.
+
+    .PARAMETER UserSid
+        Resolved SID, if available.
+
+    .PARAMETER ProfilePath
+        Resolved profile folder path.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+#>
 function NewResolvedUserContext {
     param(
         [string]$UserName,
@@ -214,6 +631,23 @@ function NewResolvedUserContext {
     }
 }
 
+<#
+    .SYNOPSIS
+        Resolve a user name to its SID with progressive fallbacks.
+
+    .DESCRIPTION
+        Tries the most authoritative sources first and degrades to heuristics
+        so the common case is fast and the degenerate case still resolves.
+        Qualified identities are pinned to their full form to avoid matching an
+        unrelated local account that happens to share the leaf name. Returns
+        $null if no source resolves.
+
+    .PARAMETER UserName
+        User name to resolve.
+
+    .OUTPUTS
+        System.String
+#>
 function ResolveUserSid {
     param(
         [Parameter(Mandatory)]
@@ -258,7 +692,8 @@ function ResolveUserSid {
         return $cachedSid
     }
 
-    # Resolve fully-qualified identities first to avoid accidentally matching a local leaf account.
+    # Resolve qualified identities via their full form first; using the bare
+    # leaf here would risk matching an unrelated local account that shares it.
     if ($hasQualifiedIdentity) {
         $resolvedSid = TryResolveSidByNtAccount -UserName $candidateUserName
         if ($resolvedSid) {
@@ -273,7 +708,8 @@ function ResolveUserSid {
         return $resolvedSid
     }
 
-    # Last-ditch NTAccount translation for non-qualified names.
+    # Last-ditch NTAccount translation for non-qualified names; qualified names
+    # already tried this path above.
     if (-not $hasQualifiedIdentity) {
         $resolvedSid = TryResolveSidByNtAccount -UserName $candidateUserName
         if ($resolvedSid) {
@@ -291,6 +727,21 @@ function ResolveUserSid {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Resolve a user name to its profile folder path.
+
+    .DESCRIPTION
+        Convenience wrapper around ResolveUserProfileContext: most callers
+        need only the path and shouldn't have to unwrap the context object
+        themselves. Returns $null if no profile is found.
+
+    .PARAMETER UserName
+        User name whose profile path is required.
+
+    .OUTPUTS
+        System.String
+#>
 function ResolveUserProfilePath {
     param(
         [Parameter(Mandatory)]
@@ -305,6 +756,22 @@ function ResolveUserProfilePath {
     return $null
 }
 
+<#
+    .SYNOPSIS
+        Resolve a user name to a full profile context (name, SID, path).
+
+    .DESCRIPTION
+        Resolves via SID-keyed registry data first (authoritative), then
+        degrades to on-disk path probing so resolution still succeeds when the
+        account or SID can't be looked up (e.g. deleted account, restricted
+        execution context). Returns $null if no profile is found.
+
+    .PARAMETER UserName
+        User name whose profile context is required.
+
+    .OUTPUTS
+        System.Management.Automation.PSCustomObject
+#>
 function ResolveUserProfileContext {
     param(
         [Parameter(Mandatory)]
@@ -372,9 +839,25 @@ function ResolveUserProfileContext {
             continue
         }
 
+        # Exact leaf match is the common case and avoids an unnecessary scan.
         $candidateUserPath = Join-Path $rootPath $candidateUserName
         if (Test-Path -LiteralPath $candidateUserPath -PathType Container) {
             return (NewResolvedUserContext -UserName $candidateUserName -UserSid $userSid -ProfilePath $candidateUserPath)
+        }
+
+        # Only domain-joined boxes can write suffixed folders, so only scan there;
+        # scanning workgroup roots would risk matching the wrong account.
+        if (Test-MachineIsDomainJoined) {
+            try {
+                foreach ($child in @(Get-ChildItem -LiteralPath $rootPath -Directory -ErrorAction SilentlyContinue)) {
+                    if (Test-UserNameMatchesProfileLeaf -UserName $candidateUserName -ProfileLeaf $child.Name) {
+                        return (NewResolvedUserContext -UserName $candidateUserName -UserSid $userSid -ProfilePath $child.FullName)
+                    }
+                }
+            }
+            catch {
+                # Fall through to the next root path.
+            }
         }
     }
 

--- a/Scripts/Helpers/ResolveUserProfilePath.ps1
+++ b/Scripts/Helpers/ResolveUserProfilePath.ps1
@@ -120,11 +120,79 @@ function GetLocalUserNameSegment {
 
 <#
     .SYNOPSIS
+        Reduce a Win32_ComputerSystem.Domain value to a NetBIOS label.
+
+    .DESCRIPTION
+        Win32_ComputerSystem.Domain may be DNS-style (e.g. contoso.com);
+        prefer Win32_NTDomain.DomainName and fall back to the first DNS label
+        so cached suffixes stay single-label (user.CONTOSO, not
+        user.contoso.com). Returns the trimmed value as-is when already a
+        single label. Falls back safely (no match) for FQDNs like
+        corp.contoso.com whose NetBIOS label is CONTOSO.
+
+    .PARAMETER RawDomain
+        Value reported by Win32_ComputerSystem.Domain.
+
+    .OUTPUTS
+        System.String
+#>
+function ResolveNetBiosDomainName {
+    param(
+        [string]$RawDomain
+    )
+
+    $trimmed = NormalizeUserLookupValue -Value $RawDomain
+    if ([string]::IsNullOrWhiteSpace($trimmed)) {
+        return ''
+    }
+
+    try {
+        # Prefer the joined-domain instance over the local SAM shadow
+        # (DomainName == COMPUTERNAME); DomainControllerName may be $null.
+        $computerName = $env:COMPUTERNAME
+        $ntDomainInstances = @(Get-CimInstance -ClassName Win32_NTDomain -OperationTimeoutSec 5 -ErrorAction Stop |
+            Where-Object {
+                -not [string]::IsNullOrWhiteSpace($_.DomainName) -and
+                $_.DomainName -ine 'WORKGROUP' -and
+                $_.DomainName -ine $computerName
+            })
+
+        $ntDomainInstance = $ntDomainInstances |
+            Where-Object { -not [string]::IsNullOrWhiteSpace($_.DomainControllerName) } |
+            Select-Object -First 1
+        if (-not $ntDomainInstance -and $ntDomainInstances.Count -gt 0) {
+            $ntDomainInstance = $ntDomainInstances | Select-Object -First 1
+        }
+
+        if ($ntDomainInstance -and -not [string]::IsNullOrWhiteSpace($ntDomainInstance.DomainName)) {
+            $fromNtDomain = NormalizeUserLookupValue -Value $ntDomainInstance.DomainName
+            if (-not [string]::IsNullOrWhiteSpace($fromNtDomain)) {
+                return $fromNtDomain
+            }
+        }
+    }
+    catch {
+        # Fall through to DNS-label derivation.
+    }
+
+    if ($trimmed.Contains('.')) {
+        $leaf = NormalizeUserLookupValue -Value (($trimmed -split '\.')[0])
+        if (-not [string]::IsNullOrWhiteSpace($leaf)) {
+            return $leaf
+        }
+    }
+
+    return $trimmed
+}
+
+<#
+    .SYNOPSIS
         Determine whether the local machine is joined to a domain.
 
     .DESCRIPTION
         Cached in script scope for the process lifetime. Returns $false on
-        error or workgroup, so callers fall back to legacy matching.
+        error or workgroup. When joined, also caches the NetBIOS domain label
+        (ResolveNetBiosDomainName) for use as a profile-folder suffix.
 
     .OUTPUTS
         System.Boolean
@@ -142,7 +210,7 @@ function Test-MachineIsDomainJoined {
         $computerSystem = Get-CimInstance -ClassName Win32_ComputerSystem -ErrorAction Stop
         if ($null -ne $computerSystem -and $computerSystem.PartOfDomain) {
             $script:MachineIsDomainJoined = $true
-            $script:MachineNetBiosDomain = [string]$computerSystem.Domain
+            $script:MachineNetBiosDomain = ResolveNetBiosDomainName -RawDomain ([string]$computerSystem.Domain)
         }
     }
     catch {
@@ -173,7 +241,7 @@ function GetProfileFolderDomainSuffix {
     $domain = $env:USERDOMAIN
     if ([string]::IsNullOrWhiteSpace($domain)) {
         # USERDOMAIN can be empty in restricted contexts; fall back to the
-        # NetBIOS domain captured by Test-MachineIsDomainJoined.
+        # cached NetBIOS label (single-label, safe as a folder suffix).
         $domain = $script:MachineNetBiosDomain
     }
     if ([string]::IsNullOrWhiteSpace($domain)) {

--- a/Scripts/Helpers/ResolveUserProfilePath.ps1
+++ b/Scripts/Helpers/ResolveUserProfilePath.ps1
@@ -59,6 +59,35 @@ function GetUserLookupCacheKey {
 
 <#
     .SYNOPSIS
+        Normalize and de-duplicate a set of user-name candidates.
+
+    .DESCRIPTION
+        Centralizes the normalize/filter/dedupe step shared by the SID
+        resolution fallbacks so the dedupe semantic lives in one place.
+        Returns @() for empty or all-blank input.
+
+    .PARAMETER Candidates
+        Equivalent name forms to normalize.
+
+    .OUTPUTS
+        System.String[]
+#>
+function GetNormalizedLookupCandidates {
+    param(
+        [string[]]$Candidates
+    )
+
+    $normalized = @($Candidates) |
+        ForEach-Object { NormalizeUserLookupValue -Value $_ } |
+        Where-Object { -not [string]::IsNullOrWhiteSpace($_) } |
+        Select-Object -Unique
+
+    # The unary comma prevents PowerShell from unwrapping a single-element array.
+    return ,@($normalized)
+}
+
+<#
+    .SYNOPSIS
         Escape a string for safe embedding in a WQL single-quoted literal.
 
     .DESCRIPTION
@@ -536,7 +565,7 @@ function TryResolveSidByLocalLookup {
         [string[]]$Candidates
     )
 
-    $lookupCandidates = @($Candidates) | ForEach-Object { NormalizeUserLookupValue -Value $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+    $lookupCandidates = GetNormalizedLookupCandidates -Candidates $Candidates
     if ($lookupCandidates.Count -eq 0) {
         return $null
     }
@@ -593,7 +622,7 @@ function TryResolveSidFromProfileList {
         [string[]]$Candidates
     )
 
-    $lookupCandidates = @($Candidates) | ForEach-Object { NormalizeUserLookupValue -Value $_ } | Where-Object { -not [string]::IsNullOrWhiteSpace($_) } | Select-Object -Unique
+    $lookupCandidates = GetNormalizedLookupCandidates -Candidates $Candidates
     if ($lookupCandidates.Count -eq 0) {
         return $null
     }
@@ -828,34 +857,6 @@ function ResolveUserSid {
         $allCacheKeys = @($candidateUserName) + $qualifiedNamesToTry | Select-Object -Unique
         SetResolvedUserSidCache -Candidates $allCacheKeys -Sid $resolvedSid
         return $resolvedSid
-    }
-
-    return $null
-}
-
-<#
-    .SYNOPSIS
-        Resolve a user name to its profile folder path.
-
-    .DESCRIPTION
-        Wrapper around ResolveUserProfileContext returning only the path.
-        Returns $null if no profile is found.
-
-    .PARAMETER UserName
-        User name whose profile path is required.
-
-    .OUTPUTS
-        System.String
-#>
-function ResolveUserProfilePath {
-    param(
-        [Parameter(Mandatory)]
-        [string]$UserName
-    )
-
-    $userContext = ResolveUserProfileContext -UserName $UserName
-    if ($userContext) {
-        return $userContext.ProfilePath
     }
 
     return $null

--- a/Scripts/Helpers/ResolveUserProfilePath.ps1
+++ b/Scripts/Helpers/ResolveUserProfilePath.ps1
@@ -3,10 +3,8 @@
         Normalize a user-name string for lookup and comparison.
 
     .DESCRIPTION
-        User input can carry zero-width characters or stray whitespace that
-        would silently break lookups and matches. Normalizing once up front
-        keeps every downstream comparison robust against purely cosmetic
-        differences. Returns an empty string for blank input.
+        Strips zero-width chars and collapses whitespace so cosmetic input
+        differences don't break downstream lookups. Returns '' for blank input.
 
     .PARAMETER Value
         Raw user-supplied name to normalize.
@@ -37,11 +35,8 @@ if (-not $script:ResolvedUserSidCache) {
         Build a form-agnostic cache key for a user name.
 
     .DESCRIPTION
-        SID resolution is expensive and called repeatedly for the same identity,
-        so the cache must be keyed by something that survives cosmetic input
-        differences. Normalizing and lower-casing ensures the same identity hits
-        regardless of case, whitespace, or qualifier form. Returns an empty
-        string for blank input.
+        Normalized + lower-cased so the same identity hits regardless of
+        case, whitespace, or qualifier form. Returns '' for blank input.
 
     .PARAMETER Value
         User name to derive a key from.
@@ -67,9 +62,8 @@ function GetUserLookupCacheKey {
         Escape a string for safe embedding in a WQL single-quoted literal.
 
     .DESCRIPTION
-        WQL string literals are single-quoted, so any embedded quote must be
-        doubled. Without this, a user-supplied name containing an apostrophe
-        could break the filter or enable WQL injection.
+        Doubles embedded single quotes; without this a user name containing
+        an apostrophe could break the WQL filter.
 
     .PARAMETER Value
         String to escape.
@@ -94,10 +88,8 @@ function EscapeWqlString {
         Extract the local name segment from a possibly domain-qualified identity.
 
     .DESCRIPTION
-        Profile folder leafs never carry the domain prefix, so qualified
-        identities (DOMAIN\user, user@domain) must be reduced to the local
-        segment before any on-disk comparison can succeed. Returns an empty
-        string for blank input.
+        Reduces DOMAIN\user or user@domain to the bare leaf, since profile
+        folder leafs never carry the domain prefix. Returns '' for blank input.
 
     .PARAMETER UserName
         User name that may be domain-qualified.
@@ -131,13 +123,8 @@ function GetLocalUserNameSegment {
         Determine whether the local machine is joined to a domain.
 
     .DESCRIPTION
-        Domain vs. workgroup selects entirely different matching rules
-        (suffix-aware vs. strict legacy), so every downstream decision needs
-        one cheap, consistent answer. Cached in script scope to avoid repeated
-        CIM round-trips. The cache is valid only for the current process
-        lifetime; joining/unjoining while the script runs is not supported.
-        Returns $false on any error or on workgroup machines, so callers
-        safely fall back to legacy matching.
+        Cached in script scope for the process lifetime. Returns $false on
+        error or workgroup, so callers fall back to legacy matching.
 
     .OUTPUTS
         System.Boolean
@@ -171,11 +158,9 @@ function Test-MachineIsDomainJoined {
 
     .DESCRIPTION
         On domain-joined machines Windows writes profile folders as
-        user.CONTOSO; knowing the suffix lets a bare user name match that
-        folder. Workgroup USERDOMAIN is just the computer name and would
-        produce false matches, so it is excluded. Falls back to the NetBIOS
-        domain captured by Test-MachineIsDomainJoined when USERDOMAIN is
-        empty in restricted execution contexts.
+        user.CONTOSO; knowing the suffix lets a bare name match that folder.
+        Excluded on workgroup (USERDOMAIN == COMPUTERNAME) to avoid false
+        matches. Returns '' when not applicable.
 
     .OUTPUTS
         System.String
@@ -187,17 +172,16 @@ function GetProfileFolderDomainSuffix {
 
     $domain = $env:USERDOMAIN
     if ([string]::IsNullOrWhiteSpace($domain)) {
-        # Some restricted execution contexts leave USERDOMAIN empty even when
-        # joined; the value captured by the Win32_ComputerSystem query is the
-        # reliable alternative.
+        # USERDOMAIN can be empty in restricted contexts; fall back to the
+        # NetBIOS domain captured by Test-MachineIsDomainJoined.
         $domain = $script:MachineNetBiosDomain
     }
     if ([string]::IsNullOrWhiteSpace($domain)) {
         return ''
     }
 
-    # USERDOMAIN == COMPUTERNAME means the box is effectively standalone; a
-    # suffix here would produce false matches instead of disambiguation.
+    # USERDOMAIN == COMPUTERNAME means effectively standalone; a suffix here
+    # would produce false matches instead of disambiguation.
     if ($domain -ieq $env:COMPUTERNAME) {
         return ''
     }
@@ -210,11 +194,9 @@ function GetProfileFolderDomainSuffix {
         Enumerate the name forms equivalent to a given identity.
 
     .DESCRIPTION
-        One identity surfaces in different forms depending on where it was
-        captured (bare, qualified, domain-suffixed). Enumerating every
-        equivalent form lets cross-source matching succeed without broadening
-        workgroup validation. Duplicates are removed. Returns an empty array
-        for blank input.
+        One identity surfaces in different forms (bare, qualified,
+        domain-suffixed); enumerating equivalents lets cross-source matching
+        succeed without broadening workgroup validation. Returns @() for blank.
 
     .PARAMETER Value
         User name to expand into equivalent forms.
@@ -240,12 +222,11 @@ function GetUserNameMatchCandidates {
         [void]$candidates.Add($localSegment)
     }
 
-    # Domain-suffixed forms only make sense where Windows actually writes them.
+    # Domain-suffixed forms only apply where Windows writes them.
     $domainSuffix = GetProfileFolderDomainSuffix
     if (-not [string]::IsNullOrWhiteSpace($domainSuffix)) {
-        # The base the suffix extends: prefer the local segment so qualified
-        # identities (DOMAIN\user) still produce user.CONTOSO rather than the
-        # fully qualified string.
+        # Prefer the local segment as the stem so DOMAIN\user still yields
+        # user.CONTOSO rather than the fully qualified string.
         $stem = if (-not [string]::IsNullOrWhiteSpace($localSegment)) { $localSegment } else { $normalized }
         if (-not [string]::IsNullOrWhiteSpace($stem)) {
             $suffixedForm = "$stem.$domainSuffix"
@@ -283,10 +264,8 @@ function GetUserNameMatchCandidates {
         Test whether a user name and a profile folder leaf share an account.
 
     .DESCRIPTION
-        A profile leaf and a user input may describe the same account in
-        different forms; comparing candidate sets instead of raw strings
-        tolerates that. Domain-joined machines also accept suffixed forms via
-        GetUserNameMatchCandidates.
+        Compares candidate sets (via GetUserNameMatchCandidates) instead of
+        raw strings, so different forms of the same account still match.
 
     .PARAMETER UserName
         User-supplied name to compare.
@@ -326,11 +305,9 @@ function Test-UserNameMatchesProfileLeaf {
         Test whether two user-name strings refer to the same account.
 
     .DESCRIPTION
-        Backups record whatever name the running session reported, which may
-        not match the restore session's form. Accepting any equivalent
-        candidate makes restore work across sessions and machine join states.
-        Workgroup stays a strict normalized equality check to avoid broadening
-        validation where suffixes aren't meaningful.
+        Accepts any equivalent candidate form so restore works across
+        sessions and join states. Workgroup stays a strict normalized equality
+        check to avoid broadening validation where suffixes aren't meaningful.
 
     .PARAMETER UserNameA
         First user name to compare.
@@ -354,8 +331,7 @@ function Test-UserNameMatch {
         return $false
     }
 
-    # Keep workgroup strict to avoid silently broadening restore scope where no
-    # suffix disambiguation exists to justify it.
+    # Workgroup: strict equality (no suffix disambiguation available).
     if (-not (Test-MachineIsDomainJoined)) {
         $normalizedA = NormalizeUserLookupValue -Value $UserNameA
         $normalizedB = NormalizeUserLookupValue -Value $UserNameB
@@ -381,9 +357,8 @@ function Test-UserNameMatch {
         Memoize a resolved SID under every equivalent name form.
 
     .DESCRIPTION
-        SID resolution is expensive and called repeatedly for the same user.
-        Memoizing under every equivalent form means later lookups short-circuit
-        regardless of which variant the caller has in hand. No-op on blank SID.
+        Keyed under all equivalent forms so later lookups short-circuit
+        regardless of which variant the caller holds. No-op on blank SID.
 
     .PARAMETER Candidates
         Equivalent name forms to key the cache entry under.
@@ -414,9 +389,7 @@ function SetResolvedUserSidCache {
         Retrieve a previously cached resolved SID.
 
     .DESCRIPTION
-        Companion to SetResolvedUserSidCache. Checks every equivalent form
-        because the caller may only hold one of them, but a prior resolution
-        under a different form should still hit. Returns $null on a miss.
+        Probes every equivalent form; returns $null on a miss.
 
     .PARAMETER Candidates
         Equivalent name forms to probe the cache with.
@@ -444,10 +417,8 @@ function GetCachedResolvedUserSid {
         Attempt SID resolution via NTAccount translation.
 
     .DESCRIPTION
-        NTAccount.Translate is the most authoritative SID source, but only
-        resolves when the name is reachable through standard security APIs.
-        Failures fall through to cheaper, broader heuristics in the caller.
-        Returns $null on failure.
+        Most authoritative name->SID source; only resolves names reachable
+        through standard security APIs. Returns $null on failure.
 
     .PARAMETER UserName
         Name to translate.
@@ -483,10 +454,8 @@ function TryResolveSidByNtAccount {
         Attempt SID resolution against the local account database.
 
     .DESCRIPTION
-        Local SAM and Win32_UserAccount are ground truth for local accounts.
-        Prefers Get-LocalUser (typed, fast) and falls back to CIM for older
-        hosts or contexts where the cmdlet is unavailable. Returns $null when
-        no candidate resolves.
+        Prefers Get-LocalUser (typed, fast), falls back to Win32_UserAccount
+        CIM for older hosts or unavailable cmdlet. Returns $null if no match.
 
     .PARAMETER Candidates
         Equivalent name forms to try.
@@ -542,10 +511,8 @@ function TryResolveSidByLocalLookup {
         Recover a SID from the ProfileList registry hive.
 
     .DESCRIPTION
-        Last-resort heuristic: when name-resolution APIs fail, the ProfileList
-        hive still links SIDs to on-disk profile folders, so matching the
-        folder leaf can recover a SID that no other source would surface.
-        Returns $null on failure.
+        Last-resort heuristic: matches the profile folder leaf to recover a
+        SID when name-resolution APIs fail. Returns $null on failure.
 
     .PARAMETER Candidates
         Equivalent name forms to match against profile folder leafs.
@@ -601,9 +568,8 @@ function TryResolveSidFromProfileList {
         Construct a resolved user context object.
 
     .DESCRIPTION
-        Bundles the resolved fields so callers don't re-derive their
-        relationship downstream or thread three loose values through every
-        call site.
+        Bundles UserName/UserSid/ProfilePath so callers don't re-derive or
+        thread three loose values.
 
     .PARAMETER UserName
         Normalized user name.
@@ -633,17 +599,68 @@ function NewResolvedUserContext {
 
 <#
     .SYNOPSIS
-        Resolve a user name to its SID with progressive fallbacks.
+        Return the qualified (DOMAIN\user) name of the current process when it matches the input.
 
     .DESCRIPTION
-        Tries the most authoritative sources first and degrades to heuristics
-        so the common case is fast and the degenerate case still resolves.
-        Qualified identities are pinned to their full form to avoid matching an
-        unrelated local account that happens to share the leaf name. Returns
-        $null if no source resolves.
+        Used to qualify a bare name on domain-joined boxes; returns $null when
+        the input doesn't match the current process identity.
+
+    .PARAMETER Candidate
+        Bare user name to compare against the current process identity.
+
+    .OUTPUTS
+        System.String
+#>
+function GetQualifiedProcessIdentityName {
+    param(
+        [string]$Candidate
+    )
+
+    $normalizedCandidate = NormalizeUserLookupValue -Value $Candidate
+    if ([string]::IsNullOrWhiteSpace($normalizedCandidate)) {
+        return $null
+    }
+
+    try {
+        $currentIdentity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+        if ($null -eq $currentIdentity) {
+            return $null
+        }
+
+        # Skip service/SYSTEM identities (no user profile).
+        $currentSidString = [string]$currentIdentity.User.Value
+        if ($currentSidString -in @('S-1-5-18', 'S-1-5-19', 'S-1-5-20')) {
+            return $null
+        }
+
+        $currentName = [string]$currentIdentity.Name
+        if ([string]::IsNullOrWhiteSpace($currentName)) {
+            return $null
+        }
+
+        $currentLocalSegment = GetLocalUserNameSegment -UserName $currentName
+        if (-not [string]::IsNullOrWhiteSpace($currentLocalSegment) -and $currentLocalSegment -ieq $normalizedCandidate) {
+            return $currentName
+        }
+    }
+    catch {
+        # Fall through to name-based resolution.
+    }
+
+    return $null
+}
+
+<#
+    .SYNOPSIS
+        Resolve a user name to its SID.
+
+    .DESCRIPTION
+        Always qualifies the input first (DOMAIN\user) and resolves that form;
+        never guesses from a bare name on domain-joined boxes to avoid
+        same-named local SAM shadowing.
 
     .PARAMETER UserName
-        User name to resolve.
+        User name to resolve. May be bare, DOMAIN\user, or user@domain.
 
     .OUTPUTS
         System.String
@@ -666,15 +683,10 @@ function ResolveUserSid {
         $leafNameCandidates = @($localNameSegment)
     }
 
-    $cacheCandidates = if ($hasQualifiedIdentity) {
+    # Unqualified inputs probe both the bare name and (for qualified inputs) the
+    # local leaf segment; qualified inputs pin to the caller's full form only.
+    $lookupCandidates = if ($hasQualifiedIdentity) {
         @($candidateUserName)
-    }
-    else {
-        @($candidateUserName) + $leafNameCandidates | Select-Object -Unique
-    }
-
-    $localLookupCandidates = if ($hasQualifiedIdentity) {
-        @()
     }
     else {
         @($candidateUserName) + $leafNameCandidates | Select-Object -Unique
@@ -687,40 +699,66 @@ function ResolveUserSid {
         @($candidateUserName)
     }
 
-    $cachedSid = GetCachedResolvedUserSid -Candidates $cacheCandidates
+    $cachedSid = GetCachedResolvedUserSid -Candidates $lookupCandidates
     if ($cachedSid) {
         return $cachedSid
     }
 
-    # Resolve qualified identities via their full form first; using the bare
-    # leaf here would risk matching an unrelated local account that shares it.
+    # Step 1: derive the qualified form(s) to resolve; never guess from a bare
+    # name on domain-joined boxes (local SAM nameshare risk).
+    $qualifiedNamesToTry = New-Object 'System.Collections.Generic.List[string]'
+
     if ($hasQualifiedIdentity) {
-        $resolvedSid = TryResolveSidByNtAccount -UserName $candidateUserName
+        # Caller already qualified; honor verbatim.
+        [void]$qualifiedNamesToTry.Add($candidateUserName)
+    }
+    elseif (Test-MachineIsDomainJoined) {
+        # Prefer process identity (authoritative), then USERDOMAIN\input.
+        $processQualifiedName = GetQualifiedProcessIdentityName -Candidate $candidateUserName
+        if (-not [string]::IsNullOrWhiteSpace($processQualifiedName)) {
+            [void]$qualifiedNamesToTry.Add($processQualifiedName)
+        }
+
+        $domainSuffix = GetProfileFolderDomainSuffix
+        if (-not [string]::IsNullOrWhiteSpace($domainSuffix)) {
+            $domainQualifiedName = "$domainSuffix\$candidateUserName"
+            if (-not ($qualifiedNamesToTry -contains $domainQualifiedName)) {
+                [void]$qualifiedNamesToTry.Add($domainQualifiedName)
+            }
+        }
+    }
+    else {
+        # Workgroup: bare name is unambiguous.
+        [void]$qualifiedNamesToTry.Add($candidateUserName)
+    }
+
+    # Step 2: resolve qualified form(s) via NTAccount.Translate.
+    foreach ($qualifiedName in $qualifiedNamesToTry) {
+        $resolvedSid = TryResolveSidByNtAccount -UserName $qualifiedName
         if ($resolvedSid) {
-            SetResolvedUserSidCache -Candidates $cacheCandidates -Sid $resolvedSid
+            $allCacheKeys = @($candidateUserName) + $qualifiedNamesToTry | Select-Object -Unique
+            SetResolvedUserSidCache -Candidates $allCacheKeys -Sid $resolvedSid
             return $resolvedSid
         }
     }
 
-    $resolvedSid = TryResolveSidByLocalLookup -Candidates $localLookupCandidates
-    if ($resolvedSid) {
-        SetResolvedUserSidCache -Candidates $cacheCandidates -Sid $resolvedSid
-        return $resolvedSid
-    }
-
-    # Last-ditch NTAccount translation for non-qualified names; qualified names
-    # already tried this path above.
-    if (-not $hasQualifiedIdentity) {
-        $resolvedSid = TryResolveSidByNtAccount -UserName $candidateUserName
+    # Step 3: local SAM fallback (workgroup only; skipped on domain to avoid
+    # nameshare shadowing).
+    if (-not (Test-MachineIsDomainJoined)) {
+        $resolvedSid = TryResolveSidByLocalLookup -Candidates $lookupCandidates
         if ($resolvedSid) {
-            SetResolvedUserSidCache -Candidates $cacheCandidates -Sid $resolvedSid
+            $allCacheKeys = @($candidateUserName) + $qualifiedNamesToTry | Select-Object -Unique
+            SetResolvedUserSidCache -Candidates $allCacheKeys -Sid $resolvedSid
             return $resolvedSid
         }
     }
 
+    # Step 4: ProfileList leaf heuristic (last resort; disambiguates by
+    # on-disk folder name, suffix-aware on domain boxes).
     $resolvedSid = TryResolveSidFromProfileList -Candidates $profileHeuristicCandidates
     if ($resolvedSid) {
-        SetResolvedUserSidCache -Candidates $cacheCandidates -Sid $resolvedSid
+        $allCacheKeys = @($candidateUserName) + $qualifiedNamesToTry | Select-Object -Unique
+        SetResolvedUserSidCache -Candidates $allCacheKeys -Sid $resolvedSid
         return $resolvedSid
     }
 
@@ -732,9 +770,8 @@ function ResolveUserSid {
         Resolve a user name to its profile folder path.
 
     .DESCRIPTION
-        Convenience wrapper around ResolveUserProfileContext: most callers
-        need only the path and shouldn't have to unwrap the context object
-        themselves. Returns $null if no profile is found.
+        Wrapper around ResolveUserProfileContext returning only the path.
+        Returns $null if no profile is found.
 
     .PARAMETER UserName
         User name whose profile path is required.
@@ -761,10 +798,10 @@ function ResolveUserProfilePath {
         Resolve a user name to a full profile context (name, SID, path).
 
     .DESCRIPTION
-        Resolves via SID-keyed registry data first (authoritative), then
-        degrades to on-disk path probing so resolution still succeeds when the
-        account or SID can't be looked up (e.g. deleted account, restricted
-        execution context). Returns $null if no profile is found.
+        SID-keyed registry data first (authoritative), then on-disk path
+        probing so resolution still succeeds when the account or SID can't be
+        looked up (deleted account, restricted context). Returns $null if not
+        found.
 
     .PARAMETER UserName
         User name whose profile context is required.
@@ -839,14 +876,14 @@ function ResolveUserProfileContext {
             continue
         }
 
-        # Exact leaf match is the common case and avoids an unnecessary scan.
+        # Exact leaf match first (common case; avoids an unnecessary scan).
         $candidateUserPath = Join-Path $rootPath $candidateUserName
         if (Test-Path -LiteralPath $candidateUserPath -PathType Container) {
             return (NewResolvedUserContext -UserName $candidateUserName -UserSid $userSid -ProfilePath $candidateUserPath)
         }
 
-        # Only domain-joined boxes can write suffixed folders, so only scan there;
-        # scanning workgroup roots would risk matching the wrong account.
+        # Only domain-joined boxes write suffixed folders; scanning workgroup
+        # roots would risk matching the wrong account.
         if (Test-MachineIsDomainJoined) {
             try {
                 foreach ($child in @(Get-ChildItem -LiteralPath $rootPath -Directory -ErrorAction SilentlyContinue)) {

--- a/Scripts/Helpers/ResolveUserProfilePath.ps1
+++ b/Scripts/Helpers/ResolveUserProfilePath.ps1
@@ -883,11 +883,11 @@ function ResolveUserProfileContext {
         [string]$UserName
     )
 
-    if ([string]::IsNullOrWhiteSpace($UserName)) {
+    $candidateUserName = NormalizeUserLookupValue -Value $UserName
+    if ([string]::IsNullOrWhiteSpace($candidateUserName)) {
         return $null
     }
 
-    $candidateUserName = NormalizeUserLookupValue -Value $UserName
     $rootPaths = @(
         (Join-Path $env:SystemDrive 'Users')
         (Split-Path -Path $env:USERPROFILE -Parent)

--- a/Scripts/Helpers/Test-TargetUserName.ps1
+++ b/Scripts/Helpers/Test-TargetUserName.ps1
@@ -15,7 +15,7 @@ function Test-TargetUserName {
         }
     }
 
-    if ($normalizedUserName -eq $env:USERNAME) {
+    if (Test-UserNameMatch -UserNameA $normalizedUserName -UserNameB $env:USERNAME) {
         return [PSCustomObject]@{
             IsValid = $false
             UserName = $normalizedUserName


### PR DESCRIPTION
Addresses #682, #692 and includes another attempt at fixing path resolution in the `Run.bat` script.

## Summary by CodeRabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
Fixed domain account username/profile resolution by reworking `Scripts/Helpers/ResolveUserProfilePath.ps1` into a domain-aware, form-agnostic resolver that uses normalized name↔SID translation and SID↔profile-leaf matching (including NetBIOS-domain label handling for profile-folder suffixes). Added lookup/memoization and candidate-generation helpers (`NormalizeUserLookupValue`, `GetNormalizedLookupCandidates`, domain-join detection, and profile-leaf equivalence matching), updated the resolution flow to prefer SID/registry data with staged SID recovery, and removed the standalone `ResolveUserProfilePath` helper in favor of `ResolveUserProfileContext` returning `ProfilePath`. Workgroup machines retain stricter local SAM/profile-folder equality behavior.

Updated domain user validation and registry backup/restore flows to use the new normalized `Test-UserNameMatch` logic instead of direct string equality: `Scripts/Helpers/Test-TargetUserName.ps1` and `Scripts/Features/RestoreRegistryBackup.ps1` now determine matches against `$env:USERNAME` via `Test-UserNameMatch`, tightening the failure condition when the extracted/parsed username is blank or doesn’t match the current logged-in user while preserving existing error messaging.

Adjusted `Run.bat` to improve robustness when launched from paths containing special characters by simplifying variable handling (`setlocal` without delayed expansion), rebuilding the Windows Terminal → PowerShell command construction with safer quote escaping for `%SCRIPT_PATH%`, and consistently routing output through `:Log`/`:Error`. Logging behavior was refined by updating `:Log` to append `echo(%* >> "%logFile%"` and updating the error path to emit a visible `ERROR:` line plus an additional logged entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->