### PR TITLE
Fix win10 icons

### DIFF
--- a/Schemas/AboutWindow.xaml
+++ b/Schemas/AboutWindow.xaml
@@ -106,7 +106,7 @@
                                 VerticalAlignment="Center"
                                 FontWeight="SemiBold"
                                 FontFamily="{DynamicResource AppIconFontFamily}"
-                                Text="{DynamicResource IconKofi}" 
+                                Text="&#xEB52;" 
                                 Foreground="{DynamicResource TitleBarCloseHoverColor}"
                                 Margin="0,0,8,0"/>
                         

--- a/Schemas/AboutWindow.xaml
+++ b/Schemas/AboutWindow.xaml
@@ -105,8 +105,8 @@
                                 HorizontalAlignment="Center"
                                 VerticalAlignment="Center"
                                 FontWeight="SemiBold"
-                                FontFamily="Segoe Fluent Icons"
-                                Text="&#xEB52;" 
+                                FontFamily="{DynamicResource AppIconFontFamily}"
+                                Text="{DynamicResource IconKofi}" 
                                 Foreground="{DynamicResource TitleBarCloseHoverColor}"
                                 Margin="0,0,8,0"/>
                         

--- a/Schemas/AppSelectionWindow.xaml
+++ b/Schemas/AppSelectionWindow.xaml
@@ -16,7 +16,7 @@
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="46"/>
             <Setter Property="Height" Value="32"/>
-            <Setter Property="FontFamily" Value="Segoe MDL2 Assets"/>
+            <Setter Property="FontFamily" Value="{DynamicResource AppIconFontFamily}"/>
             <Setter Property="FontSize" Value="10"/>
             <Setter Property="Template">
                 <Setter.Value>

--- a/Schemas/ApplyChangesWindow.xaml
+++ b/Schemas/ApplyChangesWindow.xaml
@@ -163,7 +163,7 @@
                                 Style="{DynamicResource ModalSecondaryStretchedButtonStyle}"
                                 AutomationProperties.Name="Support the creator">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <TextBlock Text="{DynamicResource IconKofi}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
+                                <TextBlock Text="&#xEB52;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
                                 <TextBlock Text="Support the creator" VerticalAlignment="Center" FontSize="14" Margin="0,0,0,1"/>
                             </StackPanel>
                         </Button>

--- a/Schemas/ApplyChangesWindow.xaml
+++ b/Schemas/ApplyChangesWindow.xaml
@@ -44,7 +44,7 @@
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
-                <TextBlock Text="&#xE8BB;" FontFamily="Segoe Fluent Icons" FontSize="10"/>
+                <TextBlock Text="&#xE8BB;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="10"/>
             </Button>
 
             <StackPanel Grid.Row="0" Grid.RowSpan="2">
@@ -54,7 +54,7 @@
                     <!-- Loading icon (spinning) -->
                     <TextBlock x:Name="ApplySpinnerIcon"
                             Text="&#xE895;" 
-                            FontFamily="Segoe Fluent Icons" 
+                            FontFamily="{DynamicResource AppIconFontFamily}" 
                             FontSize="36" 
                             Foreground="{DynamicResource ButtonBgColor}" 
                             HorizontalAlignment="Center" 
@@ -115,7 +115,7 @@
                     <!-- Success icon -->
                     <TextBlock x:Name="ApplyCompletionIcon" 
                             Text="&#xE73E;" 
-                            FontFamily="Segoe Fluent Icons" 
+                            FontFamily="{DynamicResource AppIconFontFamily}" 
                             FontSize="40"
                             Foreground="{DynamicResource ButtonBgColor}" 
                             HorizontalAlignment="Center" 
@@ -141,7 +141,7 @@
                     <StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,0,0,6">
                             <TextBlock Text="&#xE7BA;"
-                                       FontFamily="Segoe Fluent Icons"
+                                       FontFamily="{DynamicResource AppIconFontFamily}"
                                        FontSize="14"
                                        Foreground="#e8912d"
                                        VerticalAlignment="Center"
@@ -163,7 +163,7 @@
                                 Style="{DynamicResource ModalSecondaryStretchedButtonStyle}"
                                 AutomationProperties.Name="Support the creator">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                <TextBlock Text="&#xEB52;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
+                                <TextBlock Text="{DynamicResource IconKofi}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
                                 <TextBlock Text="Support the creator" VerticalAlignment="Center" FontSize="14" Margin="0,0,0,1"/>
                             </StackPanel>
                         </Button>

--- a/Schemas/MainWindow.xaml
+++ b/Schemas/MainWindow.xaml
@@ -65,7 +65,7 @@
 
         <!-- Category header icon style -->
         <Style x:Key="CategoryHeaderIcon" TargetType="TextBlock">
-            <Setter Property="FontFamily" Value="Segoe Fluent Icons"/>
+            <Setter Property="FontFamily" Value="{DynamicResource AppIconFontFamily}"/>
             <Setter Property="FontSize" Value="20"/>
             <Setter Property="LineHeight" Value="20"/>
             <Setter Property="Foreground" Value="{DynamicResource AppFgColor}"/>
@@ -196,7 +196,7 @@
             <Setter Property="BorderThickness" Value="0"/>
             <Setter Property="Width" Value="46"/>
             <Setter Property="Height" Value="32"/>
-            <Setter Property="FontFamily" Value="Segoe Fluent Icons"/>
+            <Setter Property="FontFamily" Value="{DynamicResource AppIconFontFamily}"/>
             <Setter Property="FontSize" Value="10"/>
             <Setter Property="Template">
                 <Setter.Value>
@@ -362,8 +362,8 @@
                             </TextBlock.Style>
                         </TextBlock>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xEB52;" FontFamily="Segoe Fluent Icons" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
-                            <Button x:Name="MenuBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xE700;" FontFamily="Segoe Fluent Icons" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Options" AutomationProperties.Name="Options">
+                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="{DynamicResource IconKofi}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
+                            <Button x:Name="MenuBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xE700;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Options" AutomationProperties.Name="Options">
                                 <Button.ContextMenu>
                                     <ContextMenu x:Name="MainMenu">
                                         <ContextMenu.Resources>
@@ -380,38 +380,38 @@
                                         </ContextMenu.Resources>
                                         <MenuItem x:Name="ImportConfigBtn" Header="Import config" AutomationProperties.Name="Import configuration">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xe838;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xe838;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="ExportConfigBtn" Header="Export config" AutomationProperties.Name="Export configuration">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xe74e;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xe74e;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="RestoreBackupBtn" Header="Restore backup" AutomationProperties.Name="Restore registry backup">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xe81c;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xe81c;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <Separator />
                                         <MenuItem x:Name="MenuDocumentation" Header="Documentation" AutomationProperties.Name="Documentation">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xe736;" FontFamily="Segoe MDL2 Assets" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xe736;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="MenuReportBug" Header="Report a bug" AutomationProperties.Name="Report a bug">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xEBE8;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="{DynamicResource IconReportBug}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="MenuLogs" Header="Logs" AutomationProperties.Name="Logs">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xf000;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="{DynamicResource IconLogs}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="MenuAbout" Header="About" AutomationProperties.Name="About">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="&#xE946;" FontFamily="Segoe Fluent Icons" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xE946;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                     </ContextMenu>
@@ -506,7 +506,7 @@
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock x:Name="UsernameTextBoxPlaceholder" Grid.Column="0" Text="Enter username" Foreground="{DynamicResource AppFgColor}" Opacity="0.7" FontSize="13" Margin="3,0,0,1" VerticalAlignment="Center" IsHitTestVisible="False"/>
                                                     <TextBox x:Name="OtherUsernameTextBox" Grid.Column="0" Style="{DynamicResource TextBoxInputStyle}" Text="" AutomationProperties.Name="Enter username"/>
-                                                    <TextBlock Grid.Column="1" Text="&#xE77B;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}" Opacity="0.7"/>
+                                                    <TextBlock Grid.Column="1" Text="&#xE77B;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}" Opacity="0.7"/>
                                                 </Grid>
                                             </Border>
                                         </Border>
@@ -517,13 +517,13 @@
                                     <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,8,0,4">
                                         <Button x:Name="HomeDefaultModeBtn" Width="227" Height="50" Style="{DynamicResource PrimaryButtonStyle}" Margin="0,0,12,0" AutomationProperties.Name="Default Mode">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <TextBlock Text="&#xe735;" FontFamily="Segoe Fluent Icons" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,-1"/>
+                                                <TextBlock Text="&#xe735;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" VerticalAlignment="Center" Margin="0,0,8,-1"/>
                                                 <TextBlock Text="Default Mode" ToolTip="Quickly select the recommended settings" FontWeight="SemiBold" VerticalAlignment="Center" FontSize="17" Margin="0,0,0,1"/>
                                             </StackPanel>
                                         </Button>
                                         <Button x:Name="HomeStartBtn" Width="227" Height="50" Style="{DynamicResource SecondaryButtonStyle}" AutomationProperties.Name="Custom Setup">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <TextBlock Text="&#xe90f;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
+                                                <TextBlock Text="&#xe90f;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,0,8,-1"/>
                                                 <TextBlock Text="Custom Setup" ToolTip="Manually select your preferred settings" FontWeight="SemiBold" VerticalAlignment="Center" FontSize="17" Margin="0,0,0,1"/>
                                             </StackPanel>
                                         </Button>
@@ -585,9 +585,9 @@
                                                 </Style>
                                             </ToggleButton.Style>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE735;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="0,1,6,0"/>
+                                                <TextBlock Text="&#xE735;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,1,6,0"/>
                                                 <TextBlock Text="Quick Select" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,1"/>
-                                                <TextBlock x:Name="PresetsArrow" Text="&#xE70D;" FontFamily="Segoe Fluent Icons" FontSize="10" VerticalAlignment="Center" RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock x:Name="PresetsArrow" Text="&#xE70D;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="10" VerticalAlignment="Center" RenderTransformOrigin="0.5,0.5">
                                                     <TextBlock.RenderTransform>
                                                         <RotateTransform x:Name="PresetsArrowRotation" Angle="0"/>
                                                     </TextBlock.RenderTransform>
@@ -596,7 +596,7 @@
                                         </ToggleButton>
                                         <Button x:Name="ClearAppSelectionBtn" ToolTip="Clear all selected apps" Style="{DynamicResource SecondaryButtonStyle}" Height="32"  Padding="10,0" Margin="0,0,10,0" AutomationProperties.Name="Clear Selection">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <TextBlock Text="&#xE711;" FontFamily="Segoe Fluent Icons" FontSize="15" VerticalAlignment="Center" Margin="0,3,6,0"/>
+                                                <TextBlock Text="&#xE711;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" VerticalAlignment="Center" Margin="0,3,6,0"/>
                                                 <TextBlock Text="Clear Selection" FontSize="13" VerticalAlignment="Center" Margin="0,0,0,1"/>
                                             </StackPanel>
                                         </Button>
@@ -627,7 +627,7 @@
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock x:Name="AppSearchPlaceholder" Grid.Column="0" Text="Search apps..." Foreground="{DynamicResource AppFgColor}" Opacity="0.7" FontSize="13" Margin="3,0,0,1" VerticalAlignment="Center" IsHitTestVisible="False"/>
                                                     <TextBox x:Name="AppSearchBox" Grid.Column="0" Style="{DynamicResource TextBoxInputStyle}" Text="" AutomationProperties.Name="Search app"/>
-                                                    <TextBlock Grid.Column="1" Text="&#xE721;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}"  Opacity="0.7"/>
+                                                    <TextBlock Grid.Column="1" Text="&#xE721;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}"  Opacity="0.7"/>
                                                 </Grid>
                                             </Border>
                                         </Border>
@@ -658,19 +658,19 @@
                                         </Grid.ColumnDefinitions>
                                         <StackPanel x:Name="HeaderNameBtn" Grid.Column="1" Orientation="Horizontal" Cursor="Hand" VerticalAlignment="Center" Style="{StaticResource SortHeaderBtnStyle}">
                                             <TextBlock Text="Name" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
-                                            <TextBlock x:Name="SortArrowName" Text="&#xE70E;" FontFamily="Segoe Fluent Icons" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
+                                            <TextBlock x:Name="SortArrowName" Text="&#xE70E;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
                                                 <TextBlock.RenderTransform><RotateTransform Angle="0"/></TextBlock.RenderTransform>
                                             </TextBlock>
                                         </StackPanel>
                                         <StackPanel x:Name="HeaderDescriptionBtn" Grid.Column="2" Orientation="Horizontal" Cursor="Hand" VerticalAlignment="Center" Margin="8,0,0,0" Style="{StaticResource SortHeaderBtnStyle}">
                                             <TextBlock Text="Description" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
-                                            <TextBlock x:Name="SortArrowDescription" Text="&#xE70E;" FontFamily="Segoe Fluent Icons" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
+                                            <TextBlock x:Name="SortArrowDescription" Text="&#xE70E;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
                                                 <TextBlock.RenderTransform><RotateTransform Angle="0"/></TextBlock.RenderTransform>
                                             </TextBlock>
                                         </StackPanel>
                                         <StackPanel x:Name="HeaderAppIdBtn" Grid.Column="3" Orientation="Horizontal" Cursor="Hand" VerticalAlignment="Center" Style="{StaticResource SortHeaderBtnStyle}">
                                             <TextBlock Text="App ID" FontWeight="SemiBold" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
-                                            <TextBlock x:Name="SortArrowAppId" Text="&#xE70E;" FontFamily="Segoe Fluent Icons" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
+                                            <TextBlock x:Name="SortArrowAppId" Text="&#xE70E;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="11" Foreground="{DynamicResource AppFgColor}" VerticalAlignment="Center" Margin="5,1,0,0" Opacity="0.3" RenderTransformOrigin="0.5,0.5">
                                                 <TextBlock.RenderTransform><RotateTransform Angle="0"/></TextBlock.RenderTransform>
                                             </TextBlock>
                                         </StackPanel>
@@ -684,7 +684,7 @@
                                         </ScrollViewer>
                                         <Border x:Name="LoadingAppsIndicator" CornerRadius="0,0,4,4" Background="{DynamicResource CardBgColor}" Opacity="0.8" Visibility="Collapsed">
                                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                <TextBlock Text="&#xF16A;" FontFamily="Segoe Fluent Icons" FontSize="28" Foreground="{DynamicResource AppFgColor}" HorizontalAlignment="Center" Margin="0,0,0,8" RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock Text="{DynamicResource IconLoadingApps}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="28" Foreground="{DynamicResource AppFgColor}" HorizontalAlignment="Center" Margin="0,0,0,8" RenderTransformOrigin="0.5,0.5">
                                                     <TextBlock.RenderTransform>
                                                         <RotateTransform Angle="0"/>
                                                     </TextBlock.RenderTransform>
@@ -789,9 +789,9 @@
                                                 </Style>
                                             </ToggleButton.Style>
                                             <StackPanel Orientation="Horizontal">
-                                                <TextBlock Text="&#xE735;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="0,1,6,0"/>
+                                                <TextBlock Text="&#xE735;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="0,1,6,0"/>
                                                 <TextBlock Text="Quick Select" FontSize="13" VerticalAlignment="Center" Margin="0,0,6,1"/>
-                                                <TextBlock x:Name="TweaksPresetsArrow" Text="&#xE70D;" FontFamily="Segoe Fluent Icons" FontSize="10" VerticalAlignment="Center" RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock x:Name="TweaksPresetsArrow" Text="&#xE70D;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="10" VerticalAlignment="Center" RenderTransformOrigin="0.5,0.5">
                                                     <TextBlock.RenderTransform>
                                                         <RotateTransform Angle="0"/>
                                                     </TextBlock.RenderTransform>
@@ -800,7 +800,7 @@
                                         </ToggleButton>
                                         <Button x:Name="ClearAllTweaksBtn" ToolTip="Clear all selected tweaks" Style="{DynamicResource SecondaryButtonStyle}" Padding="10,0" Height="32" Margin="0,0,10,0" AutomationProperties.Name="Clear Selection">
                                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                                <TextBlock Text="&#xE711;" FontFamily="Segoe Fluent Icons" FontSize="15" VerticalAlignment="Center" Margin="0,3,6,0"/>
+                                                <TextBlock Text="&#xE711;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" VerticalAlignment="Center" Margin="0,3,6,0"/>
                                                 <TextBlock Text="Clear Selection" FontSize="13" VerticalAlignment="Center" Margin="0,0,0,1"/>
                                             </StackPanel>
                                         </Button>
@@ -832,7 +832,7 @@
                                                     </Grid.ColumnDefinitions>
                                                     <TextBlock x:Name="TweakSearchPlaceholder" Grid.Column="0" Text="Search tweaks..." Foreground="{DynamicResource AppFgColor}" Opacity="0.7" FontSize="13" Margin="3,0,0,1" VerticalAlignment="Center" IsHitTestVisible="False"/>
                                                     <TextBox x:Name="TweakSearchBox" Grid.Column="0" Style="{DynamicResource TextBoxInputStyle}" Text="" AutomationProperties.Name="Search tweaks"/>
-                                                    <TextBlock Grid.Column="1" Text="&#xE721;" FontFamily="Segoe Fluent Icons" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}" Opacity="0.7"/>
+                                                    <TextBlock Grid.Column="1" Text="&#xE721;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="14" VerticalAlignment="Center" Margin="8,0,4,0" Foreground="{DynamicResource AppFgColor}" Opacity="0.7"/>
                                                 </Grid>
                                             </Border>
                                         </Border>
@@ -986,7 +986,7 @@
                                 </Button>
                                 <Button x:Name="DeploymentApplyBtn" Style="{DynamicResource PrimaryButtonStyle}" Width="200" Height="44" HorizontalAlignment="Center" AutomationProperties.Name="Apply Changes">
                                     <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                                        <TextBlock Text="&#xE73E;" FontFamily="Segoe Fluent Icons" FontSize="20" FontWeight="SemiBold" VerticalAlignment="Center"/>
+                                        <TextBlock Text="&#xE73E;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="20" FontWeight="SemiBold" VerticalAlignment="Center"/>
                                         <TextBlock Text="Apply Changes" VerticalAlignment="Center" FontSize="18" FontWeight="SemiBold" Margin="8,0,0,4"/>
                                     </StackPanel>
                                 </Button>
@@ -1006,7 +1006,7 @@
                     </Grid.ColumnDefinitions>
                     <Button x:Name="PreviousBtn" Grid.Column="0" Width="120" Height="36" Style="{DynamicResource SecondaryButtonStyle}" Visibility="Collapsed" AutomationProperties.Name="Back">
                         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
-                            <TextBlock Text="&#xE72B;" FontFamily="Segoe Fluent Icons" FontSize="12" Margin="0,0,8,0" VerticalAlignment="Center"/>
+                            <TextBlock Text="&#xE72B;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="12" Margin="0,0,8,0" VerticalAlignment="Center"/>
                             <TextBlock Text="Back" VerticalAlignment="Center" FontSize="14" Margin="0,0,0,3"/>
                         </StackPanel>
                     </Button>
@@ -1015,7 +1015,7 @@
                         <Button x:Name="NextBtn" Width="120" Height="36" Style="{DynamicResource PrimaryButtonStyle}" AutomationProperties.Name="Next">
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
                                 <TextBlock Text="Next" VerticalAlignment="Center" FontSize="14" Margin="0,0,0,3"/>
-                                <TextBlock Text="&#xE72A;" FontFamily="Segoe Fluent Icons" FontSize="12" Margin="8,0,0,0" VerticalAlignment="Center"/>
+                                <TextBlock Text="&#xE72A;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="12" Margin="8,0,0,0" VerticalAlignment="Center"/>
                             </StackPanel>
                         </Button>
                     </StackPanel>

--- a/Schemas/MainWindow.xaml
+++ b/Schemas/MainWindow.xaml
@@ -362,8 +362,8 @@
                             </TextBlock.Style>
                         </TextBlock>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xEB52;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
-                            <Button x:Name="MenuBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xE700;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Options" AutomationProperties.Name="Options">
+                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xEB52;" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
+                            <Button x:Name="MenuBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xE700;" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Options" AutomationProperties.Name="Options">
                                 <Button.ContextMenu>
                                     <ContextMenu x:Name="MainMenu">
                                         <ContextMenu.Resources>

--- a/Schemas/MainWindow.xaml
+++ b/Schemas/MainWindow.xaml
@@ -362,7 +362,7 @@
                             </TextBlock.Style>
                         </TextBlock>
                         <StackPanel Grid.Column="1" Orientation="Horizontal">
-                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="{DynamicResource IconKofi}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
+                            <Button x:Name="KofiBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xEB52;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Support the creator" AutomationProperties.Name="Support the creator"/>
                             <Button x:Name="MenuBtn" shell:WindowChrome.IsHitTestVisibleInChrome="True" Content="&#xE700;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="15" Style="{StaticResource TitlebarButton}" ToolTip="Options" AutomationProperties.Name="Options">
                                 <Button.ContextMenu>
                                     <ContextMenu x:Name="MainMenu">
@@ -401,12 +401,12 @@
                                         </MenuItem>
                                         <MenuItem x:Name="MenuReportBug" Header="Report a bug" AutomationProperties.Name="Report a bug">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="{DynamicResource IconReportBug}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xEBE8;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="MenuLogs" Header="Logs" AutomationProperties.Name="Logs">
                                             <MenuItem.Icon>
-                                                <TextBlock Text="{DynamicResource IconLogs}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
+                                                <TextBlock Text="&#xf000;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="16" Foreground="{DynamicResource AppFgColor}"/>
                                             </MenuItem.Icon>
                                         </MenuItem>
                                         <MenuItem x:Name="MenuAbout" Header="About" AutomationProperties.Name="About">
@@ -684,7 +684,7 @@
                                         </ScrollViewer>
                                         <Border x:Name="LoadingAppsIndicator" CornerRadius="0,0,4,4" Background="{DynamicResource CardBgColor}" Opacity="0.8" Visibility="Collapsed">
                                             <StackPanel HorizontalAlignment="Center" VerticalAlignment="Center">
-                                                <TextBlock Text="{DynamicResource IconLoadingApps}" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="28" Foreground="{DynamicResource AppFgColor}" HorizontalAlignment="Center" Margin="0,0,0,8" RenderTransformOrigin="0.5,0.5">
+                                                <TextBlock Text="&#xF16A;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="28" Foreground="{DynamicResource AppFgColor}" HorizontalAlignment="Center" Margin="0,0,0,8" RenderTransformOrigin="0.5,0.5">
                                                     <TextBlock.RenderTransform>
                                                         <RotateTransform Angle="0"/>
                                                     </TextBlock.RenderTransform>

--- a/Schemas/MessageBox.xaml
+++ b/Schemas/MessageBox.xaml
@@ -49,7 +49,7 @@
                 <!-- Icon -->
                 <TextBlock x:Name="IconText"
                            Grid.Column="0"
-                           FontFamily="Segoe Fluent Icons"
+                           FontFamily="{DynamicResource AppIconFontFamily}"
                            FontSize="24"
                            Foreground="{DynamicResource AppFgColor}"
                            VerticalAlignment="Center"

--- a/Schemas/RestoreBackupWindow.xaml
+++ b/Schemas/RestoreBackupWindow.xaml
@@ -134,7 +134,7 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0"
-                                           Text="{DynamicResource IconRegistryRestore}"
+                                           Text="&#xEF58;"
                                            FontFamily="{DynamicResource AppIconFontFamily}"
                                            FontSize="24"
                                            VerticalAlignment="Center"

--- a/Schemas/RestoreBackupWindow.xaml
+++ b/Schemas/RestoreBackupWindow.xaml
@@ -92,7 +92,7 @@
                         </Style.Triggers>
                     </Style>
                 </Button.Style>
-                <TextBlock Text="&#xE8BB;" FontFamily="Segoe Fluent Icons" FontSize="10"/>
+                <TextBlock Text="&#xE8BB;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="10"/>
             </Button>
 
             <ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto" Margin="0">
@@ -134,8 +134,8 @@
                                     <ColumnDefinition Width="*"/>
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0"
-                                           Text="&#xEF58;"
-                                           FontFamily="Segoe Fluent Icons"
+                                           Text="{DynamicResource IconRegistryRestore}"
+                                           FontFamily="{DynamicResource AppIconFontFamily}"
                                            FontSize="24"
                                            VerticalAlignment="Center"
                                            Margin="14,0,14,0"/>
@@ -165,7 +165,7 @@
                                 </Grid.ColumnDefinitions>
                                 <TextBlock Grid.Column="0"
                                            Text="&#xE8FC;"
-                                           FontFamily="Segoe Fluent Icons"
+                                           FontFamily="{DynamicResource AppIconFontFamily}"
                                            FontSize="24"
                                            VerticalAlignment="Center"
                                            Margin="14,0,14,0"/>

--- a/Schemas/SharedStyles.xaml
+++ b/Schemas/SharedStyles.xaml
@@ -272,7 +272,7 @@
                                                 <Border x:Name="Border" Background="{TemplateBinding Background}" BorderBrush="{TemplateBinding BorderBrush}" BorderThickness="{TemplateBinding BorderThickness}" CornerRadius="4">
                                                     <TextBlock x:Name="Arrow"
                                                                Text="&#xE70D;"
-                                                               FontFamily="Segoe Fluent Icons"
+                                                               FontFamily="{DynamicResource AppIconFontFamily}"
                                                                FontSize="10"
                                                                HorizontalAlignment="Right"
                                                                VerticalAlignment="Center"
@@ -393,12 +393,12 @@
                             </Grid.ColumnDefinitions>
                             <Border x:Name="CheckBoxBorder" Grid.Column="0" Width="20" Height="20" Background="{DynamicResource CheckBoxBgColor}" BorderBrush="{DynamicResource CheckBoxBorderColor}" BorderThickness="1" CornerRadius="4" Margin="0,0,8,0">
                                 <Grid>
-                                    <TextBlock x:Name="CheckMark" Text="&#xE73E;" FontFamily="Segoe Fluent Icons" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource ButtonBgColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0">
+                                    <TextBlock x:Name="CheckMark" Text="&#xE73E;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="13" FontWeight="SemiBold" Foreground="{DynamicResource ButtonBgColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0">
                                         <TextBlock.Clip>
                                             <RectangleGeometry x:Name="CheckMarkClip" Rect="0,0,0,16"/>
                                         </TextBlock.Clip>
                                     </TextBlock>
-                                    <TextBlock x:Name="IndeterminateMark" Text="&#xe9ae;" FontFamily="Segoe Fluent Icons" FontSize="13" FontWeight="Bold" Foreground="{DynamicResource ButtonBgColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0" Margin="1,0,0,1">
+                                    <TextBlock x:Name="IndeterminateMark" Text="&#xe9ae;" FontFamily="{DynamicResource AppIconFontFamily}" FontSize="13" FontWeight="Bold" Foreground="{DynamicResource ButtonBgColor}" HorizontalAlignment="Center" VerticalAlignment="Center" Opacity="0" Margin="1,0,0,1">
                                         <TextBlock.Clip>
                                             <RectangleGeometry x:Name="IndeterminateMarkClip" Rect="0,0,0,12"/>
                                         </TextBlock.Clip>

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -129,9 +129,20 @@ function Build-DynamicTweaks {
 
         # Add category icon
         $icon = New-Object System.Windows.Controls.TextBlock
-        # Convert HTML entity to character (e.g., &#xE72E; -> actual character)
+        # Convert HTML entity to character (e.g., &#xE72E; -> actual character).
+        # Category icons are defined in Features.json with Fluent codepoints; on
+        # Windows 10 (build < 22000), Segoe MDL2 Assets does not include some of
+        # the higher-range codepoints, so remap the Fluent-only ones to MDL2-safe
+        # equivalents before assigning the icon text.
+        $win10CategoryIconRemap = @{
+            0xEC50 = 0xE8B7  # FileExplorer: E8B7 (folder)
+            0xEFDA = 0xE771  # OptionalWindowsFeatures: E771 (gear/settings)
+        }
         if ($categoryIcon -match '&#x([0-9A-Fa-f]+);') {
             $hexValue = [Convert]::ToInt32($matches[1], 16)
+            if ($WinVersion -lt 22000 -and $win10CategoryIconRemap.ContainsKey($hexValue)) {
+                $hexValue = $win10CategoryIconRemap[$hexValue]
+            }
             $icon.Text = [char]$hexValue
         }
         $icon.Style = $Window.Resources['CategoryHeaderIcon']

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -204,9 +204,8 @@ function Build-DynamicTweaks {
     foreach ($categoryObj in $orderedCategories) {
         $categoryName = $categoryObj.Name
 
-        # Create/get card for this category
-        $panel = GetOrCreateCategoryCard -categoryObj $categoryObj
-        if (-not $panel) { continue }
+        # Card is created lazily on the first rendered item
+        $panel = $null
 
         # Collect groups and features for this category, then sort by priority
         $categoryItems = @()
@@ -290,6 +289,7 @@ function Build-DynamicTweaks {
                         if ($soleFeature.FeatureId -match '^Disable') { $opt = 'Disable' } elseif ($soleFeature.FeatureId -match '^Enable') { $opt = 'Enable' }
                         $items = @('No Change', $opt)
                         $comboName = ("Feature_{0}_Combo" -f $soleFeature.FeatureId) -replace '[^a-zA-Z0-9_]', ''
+                        if (-not $panel) { $panel = GetOrCreateCategoryCard -categoryObj $categoryObj }
                         $combo = CreateLabeledCombo -parent $panel -labelText $soleFeature.Label -comboName $comboName -items $items
                         # attach tooltip from Features.json if present
                         if ($soleFeature.ToolTip -or $soleFeature.DisableWhenApplied -eq $true) {
@@ -314,6 +314,7 @@ function Build-DynamicTweaks {
 
                 $items = @('No Change') + ($filteredValues | ForEach-Object { $_.Label })
                 $comboName = 'Group_{0}Combo' -f $group.GroupId
+                if (-not $panel) { $panel = GetOrCreateCategoryCard -categoryObj $categoryObj }
                 $combo = CreateLabeledCombo -parent $panel -labelText $group.Label -comboName $comboName -items $items
                 # attach tooltip from UiGroups if present
                 if ($group.ToolTip) {
@@ -334,6 +335,7 @@ function Build-DynamicTweaks {
                 if ($feature.FeatureId -match '^Disable') { $opt = 'Disable' } elseif ($feature.FeatureId -match '^Enable') { $opt = 'Enable' }
                 $items = @('No Change', $opt)
                 $comboName = ("Feature_{0}_Combo" -f $feature.FeatureId) -replace '[^a-zA-Z0-9_]', ''
+                if (-not $panel) { $panel = GetOrCreateCategoryCard -categoryObj $categoryObj }
                 $combo = CreateLabeledCombo -parent $panel -labelText $feature.Label -comboName $comboName -items $items
                 # attach tooltip from Features.json if present, and include the disabled-state reason
                 if ($feature.ToolTip -or $feature.DisableWhenApplied -eq $true) {

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -130,18 +130,10 @@ function Build-DynamicTweaks {
         # Add category icon
         $icon = New-Object System.Windows.Controls.TextBlock
         # Convert HTML entity to character (e.g., &#xE72E; -> actual character).
-        # Category icons are defined in Features.json with Fluent codepoints; on
-        # Windows 10 (build < 22000), Segoe MDL2 Assets does not include some of
-        # the higher-range codepoints, so remap the Fluent-only ones to MDL2-safe
-        # equivalents before assigning the icon text.
-        $win10CategoryIconRemap = @{
-            0xEC50 = 0xE8B7  # FileExplorer: E8B7 (folder)
-            0xEFDA = 0xE771  # OptionalWindowsFeatures: E771 (gear/settings)
-        }
         if ($categoryIcon -match '&#x([0-9A-Fa-f]+);') {
             $hexValue = [Convert]::ToInt32($matches[1], 16)
-            if ($WinVersion -lt 22000 -and $win10CategoryIconRemap.ContainsKey($hexValue)) {
-                $hexValue = $win10CategoryIconRemap[$hexValue]
+            if ($WinVersion -lt 22000 -and $hexValue -eq 0xE794) {
+                $hexValue = 0xE734
             }
             $icon.Text = [char]$hexValue
         }

--- a/Scripts/GUI/MainWindow-TweaksBuilder.ps1
+++ b/Scripts/GUI/MainWindow-TweaksBuilder.ps1
@@ -129,7 +129,7 @@ function Build-DynamicTweaks {
 
         # Add category icon
         $icon = New-Object System.Windows.Controls.TextBlock
-        # Convert HTML entity to character (e.g., &#xE72E; -> actual character).
+        # Convert HTML entity to character (e.g., &#xE72E; -> actual character)
         if ($categoryIcon -match '&#x([0-9A-Fa-f]+);') {
             $hexValue = [Convert]::ToInt32($matches[1], 16)
             if ($WinVersion -lt 22000 -and $hexValue -eq 0xE794) {

--- a/Scripts/GUI/SetWindowThemeResources.ps1
+++ b/Scripts/GUI/SetWindowThemeResources.ps1
@@ -124,12 +124,7 @@ function SetWindowThemeResources {
 
     # Segoe Fluent Icons ships only on Windows 11 (build >= 22000). 
     # On Windows 10, fall back to Segoe MDL2 Assets.
-    $winBuild = 0
-    try {
-        $winBuild = [int](Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' CurrentBuild -ErrorAction Stop)
-    }
-    catch { }
-
+    $winBuild = Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' CurrentBuild
     $iconFontName = if ($winBuild -ge 22000) { 'Segoe Fluent Icons' } else { 'Segoe MDL2 Assets' }
     $window.Resources['AppIconFontFamily'] = [System.Windows.Media.FontFamily]::new($iconFontName)
 

--- a/Scripts/GUI/SetWindowThemeResources.ps1
+++ b/Scripts/GUI/SetWindowThemeResources.ps1
@@ -7,7 +7,8 @@
     populates the window's Resources with SolidColorBrush entries keyed by
     category and resource name (e.g. "AppAccentColor"). Additionally loads and
     merges shared XAML styles from the script's SharedStylesSchema path if
-    available.
+    available. Also resolves the icon font: Segoe Fluent Icons on Windows 11
+    and Segoe MDL2 Assets on Windows 10.
 
     .PARAMETER window
     The WPF Window whose resource dictionary will be populated.

--- a/Scripts/GUI/SetWindowThemeResources.ps1
+++ b/Scripts/GUI/SetWindowThemeResources.ps1
@@ -122,10 +122,8 @@ function SetWindowThemeResources {
         }
     }
 
-    # ---- Per-OS icon font ----
-    # Segoe Fluent Icons ships only on Windows 11 (build >= 22000). On Windows 10,
-    # fall back to Segoe MDL2 Assets, which is present on every supported Windows 10
-    # build and still installed on Windows 11.
+    # Segoe Fluent Icons ships only on Windows 11 (build >= 22000). 
+    # On Windows 10, fall back to Segoe MDL2 Assets.
     $winBuild = 0
     try {
         $winBuild = [int](Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' CurrentBuild -ErrorAction Stop)

--- a/Scripts/GUI/SetWindowThemeResources.ps1
+++ b/Scripts/GUI/SetWindowThemeResources.ps1
@@ -122,6 +122,37 @@ function SetWindowThemeResources {
         }
     }
 
+    # ---- Per-OS icon font + glyph fallbacks ----
+    # Segoe Fluent Icons ships only on Windows 11 (build >= 22000). On Windows 10,
+    # fall back to Segoe MDL2 Assets, which is present on every supported Windows 10
+    # build and still installed on Windows 11.
+    $winBuild = 0
+    try {
+        $winBuild = [int](Get-ItemPropertyValue 'HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion' CurrentBuild -ErrorAction Stop)
+    }
+    catch { }
+
+    $iconFontName = if ($winBuild -ge 22000) { 'Segoe Fluent Icons' } else { 'Segoe MDL2 Assets' }
+    $window.Resources['AppIconFontFamily'] = [System.Windows.Media.FontFamily]::new($iconFontName)
+
+    # Fluent-only glyph codepoints that have no (or unreliable) counterpart in
+    # Segoe MDL2 Assets. On Windows 10 we supply MDL2-safe equivalents; on
+    # Windows 11 we keep the original Fluent codepoints.
+    if ($winBuild -ge 22000) {
+        $window.Resources['IconKofi']            = [string][char]0xEB52
+        $window.Resources['IconReportBug']       = [string][char]0xEBE8
+        $window.Resources['IconLogs']            = [string][char]0xF000
+        $window.Resources['IconLoadingApps']     = [string][char]0xF16A
+        $window.Resources['IconRegistryRestore'] = [string][char]0xEF58
+    }
+    else {
+        $window.Resources['IconKofi']            = [string][char]0xE8B9  # Heart
+        $window.Resources['IconReportBug']       = [string][char]0xE7BA  # Warning / alert
+        $window.Resources['IconLogs']            = [string][char]0xE7C4  # Notes / journal
+        $window.Resources['IconLoadingApps']     = [string][char]0xE895  # ProgressRing spinner
+        $window.Resources['IconRegistryRestore'] = [string][char]0xE751  # Restore
+    }
+
     # Load and merge shared styles
     if ($script:SharedStylesSchema -and (Test-Path $script:SharedStylesSchema)) {
         $sharedXaml = Get-Content -Path $script:SharedStylesSchema -Raw

--- a/Scripts/GUI/SetWindowThemeResources.ps1
+++ b/Scripts/GUI/SetWindowThemeResources.ps1
@@ -122,7 +122,7 @@ function SetWindowThemeResources {
         }
     }
 
-    # ---- Per-OS icon font + glyph fallbacks ----
+    # ---- Per-OS icon font ----
     # Segoe Fluent Icons ships only on Windows 11 (build >= 22000). On Windows 10,
     # fall back to Segoe MDL2 Assets, which is present on every supported Windows 10
     # build and still installed on Windows 11.
@@ -134,24 +134,6 @@ function SetWindowThemeResources {
 
     $iconFontName = if ($winBuild -ge 22000) { 'Segoe Fluent Icons' } else { 'Segoe MDL2 Assets' }
     $window.Resources['AppIconFontFamily'] = [System.Windows.Media.FontFamily]::new($iconFontName)
-
-    # Fluent-only glyph codepoints that have no (or unreliable) counterpart in
-    # Segoe MDL2 Assets. On Windows 10 we supply MDL2-safe equivalents; on
-    # Windows 11 we keep the original Fluent codepoints.
-    if ($winBuild -ge 22000) {
-        $window.Resources['IconKofi']            = [string][char]0xEB52
-        $window.Resources['IconReportBug']       = [string][char]0xEBE8
-        $window.Resources['IconLogs']            = [string][char]0xF000
-        $window.Resources['IconLoadingApps']     = [string][char]0xF16A
-        $window.Resources['IconRegistryRestore'] = [string][char]0xEF58
-    }
-    else {
-        $window.Resources['IconKofi']            = [string][char]0xE8B9  # Heart
-        $window.Resources['IconReportBug']       = [string][char]0xE7BA  # Warning / alert
-        $window.Resources['IconLogs']            = [string][char]0xE7C4  # Notes / journal
-        $window.Resources['IconLoadingApps']     = [string][char]0xE895  # ProgressRing spinner
-        $window.Resources['IconRegistryRestore'] = [string][char]0xE751  # Restore
-    }
 
     # Load and merge shared styles
     if ($script:SharedStylesSchema -and (Test-Path $script:SharedStylesSchema)) {


### PR DESCRIPTION
This addresses #602, icons now fall back to `Segoe MDL2 Assets` icons on Windows 10.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR fixes Windows 10 icon rendering (issue `#602`) by introducing an `AppIconFontFamily` dynamic resource and updating the UI to render icon glyphs via this resource rather than hardcoded Segoe icon fonts, so Windows 10 falls back to **Segoe MDL2 Assets** while Windows 11 uses **Segoe Fluent Icons**.

It switches `FontFamily` usage across multiple XAML windows and shared templates to `{DynamicResource AppIconFontFamily}`—including `AboutWindow.xaml`, `AppSelectionWindow.xaml`, `ApplyChangesWindow.xaml`, `MainWindow.xaml`, `MessageBox.xaml`, `RestoreBackupWindow.xaml`, and `SharedStyles.xaml` (combo box dropdown arrow and checkbox check/indeterminate glyphs).

It also updates `Scripts/GUI/SetWindowThemeResources.ps1` to set `AppIconFontFamily` based on the detected Windows build (`>= 22000` → Segoe Fluent Icons, otherwise Segoe MDL2 Assets) before loading/merging shared XAML styles. Finally, `Scripts/GUI/MainWindow-TweaksBuilder.ps1` is refined to (1) lazily create per-category cards only when needed and (2) remap a specific `< 22000` icon codepoint (`0xE794` → `0xE734`) for one parsed category icon.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->