### PR TITLE
Fix: Show reboot warning for undoing features that require it

### DIFF
--- a/Scripts/Features/RestartExplorer.ps1
+++ b/Scripts/Features/RestartExplorer.ps1
@@ -17,10 +17,13 @@ function RestartExplorer {
         return
     }
 
-    foreach ($paramKey in $script:Params.Keys) {
+    $candidateParamKeys = @($script:Params.Keys) + @($script:UndoParams.Keys)
+    foreach ($paramKey in $candidateParamKeys) {
         if ($script:Features.ContainsKey($paramKey) -and $script:Features[$paramKey].RequiresReboot -eq $true) {
             $feature = $script:Features[$paramKey]
-            Write-Host "Warning: '$($feature.Label)' requires a reboot to take full effect" -ForegroundColor Yellow
+            $isUndo = $script:UndoParams.ContainsKey($paramKey)
+            $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
+            Write-Host "Warning: '$displayLabel' requires a reboot to take full effect" -ForegroundColor Yellow
         }
     }
 

--- a/Scripts/Features/RestartExplorer.ps1
+++ b/Scripts/Features/RestartExplorer.ps1
@@ -18,7 +18,7 @@ function RestartExplorer {
         return
     }
 
-    $rebootFeatures = @(Get-RebootFeatureLabels)
+    $rebootFeatures = Get-RebootFeatureLabels
     foreach ($displayLabel in $rebootFeatures) {
         Write-Host "Warning: '$displayLabel' requires a reboot to take full effect" -ForegroundColor Yellow
     }

--- a/Scripts/Features/RestartExplorer.ps1
+++ b/Scripts/Features/RestartExplorer.ps1
@@ -18,14 +18,9 @@ function RestartExplorer {
         return
     }
 
-    $candidateParamKeys = @($script:Params.Keys) + @($script:UndoParams.Keys)
-    foreach ($paramKey in $candidateParamKeys) {
-        if ($script:Features.ContainsKey($paramKey) -and $script:Features[$paramKey].RequiresReboot -eq $true) {
-            $feature = $script:Features[$paramKey]
-            $isUndo = $script:UndoParams.ContainsKey($paramKey)
-            $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
-            Write-Host "Warning: '$displayLabel' requires a reboot to take full effect" -ForegroundColor Yellow
-        }
+    $rebootFeatures = @(Get-RebootFeatureLabels)
+    foreach ($displayLabel in $rebootFeatures) {
+        Write-Host "Warning: '$displayLabel' requires a reboot to take full effect" -ForegroundColor Yellow
     }
 
     # Only restart if the powershell process matches the OS architecture.

--- a/Scripts/Features/RestartExplorer.ps1
+++ b/Scripts/Features/RestartExplorer.ps1
@@ -1,10 +1,11 @@
-# Restart the Windows Explorer process
-function RestartExplorer {
-    # Restarting Explorer while running in Sysprep or User context is not necessary
-    if ($script:Params.ContainsKey("Sysprep") -or $script:Params.ContainsKey("User")) {
-        return
-    }
+<#
+    .SYNOPSIS
+    Restarts Windows Explorer to apply system changes.
 
+    .DESCRIPTION
+    Restarts the Explorer process to ensure all UI modifications take effect. Shows a warning if any of the applied features require a reboot to take full effect.
+#>
+function RestartExplorer {
     if ($script:Params.ContainsKey("WhatIf")) {
         Write-Host "[WhatIf] Restart the Windows Explorer process" -ForegroundColor Cyan
         return

--- a/Scripts/GUI/MainWindow-Deployment.ps1
+++ b/Scripts/GUI/MainWindow-Deployment.ps1
@@ -13,6 +13,13 @@ function Get-UndoFeatureLabel {
     return [string]$script:FeatureLabelLookup[$FeatureId]
 }
 
+<#
+    .SYNOPSIS
+    Returns the tweak actions that are pending based on the current UI state.
+
+    .OUTPUTS
+    [PSCustomObject[]] Objects with Action, FeatureId, and Label properties.
+#>
 function Get-PendingTweakActions {
     param(
         [System.Windows.Window]$Window,

--- a/Scripts/GUI/MainWindow-Deployment.ps1
+++ b/Scripts/GUI/MainWindow-Deployment.ps1
@@ -54,7 +54,7 @@ function Get-PendingTweakActions {
                 $actions.Add([PSCustomObject]@{
                         Action    = 'Undo'
                         FeatureId = [string]$mapping.FeatureId
-                        Label     = [string]$script:FeatureLabelLookup[$mapping.FeatureId]
+                        Label     = [string](Get-UndoFeatureLabel -FeatureId $mapping.FeatureId)
                     })
             }
         }

--- a/Scripts/GUI/Show-ApplyModal.ps1
+++ b/Scripts/GUI/Show-ApplyModal.ps1
@@ -144,16 +144,7 @@ function Show-ApplyModal {
 
                 # Show completion message with reboot instructions if any applied features require reboot
                 if ($RestartExplorer) {
-                    $rebootFeatures = @()
-                    $candidateParamKeys = @($script:Params.Keys) + @($script:UndoParams.Keys)
-                    foreach ($paramKey in $candidateParamKeys) {
-                        if ($script:Features.ContainsKey($paramKey) -and $script:Features[$paramKey].RequiresReboot -eq $true) {
-                            $feature = $script:Features[$paramKey]
-                            $isUndo = $script:UndoParams.ContainsKey($paramKey)
-                            $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
-                            $rebootFeatures += "$displayLabel"
-                        }
-                    }
+                    $rebootFeatures = @(Get-RebootFeatureLabels)
 
                     if ($rebootFeatures.Count -gt 0) {
                         foreach ($featureName in $rebootFeatures) {

--- a/Scripts/GUI/Show-ApplyModal.ps1
+++ b/Scripts/GUI/Show-ApplyModal.ps1
@@ -144,7 +144,7 @@ function Show-ApplyModal {
 
                 # Show completion message with reboot instructions if any applied features require reboot
                 if ($RestartExplorer) {
-                    $rebootFeatures = @(Get-RebootFeatureLabels)
+                    $rebootFeatures = Get-RebootFeatureLabels
 
                     if ($rebootFeatures.Count -gt 0) {
                         foreach ($featureName in $rebootFeatures) {

--- a/Scripts/GUI/Show-ApplyModal.ps1
+++ b/Scripts/GUI/Show-ApplyModal.ps1
@@ -145,10 +145,13 @@ function Show-ApplyModal {
                 # Show completion message with reboot instructions if any applied features require reboot
                 if ($RestartExplorer) {
                     $rebootFeatures = @()
-                    foreach ($paramKey in $script:Params.Keys) {
+                    $candidateParamKeys = @($script:Params.Keys) + @($script:UndoParams.Keys)
+                    foreach ($paramKey in $candidateParamKeys) {
                         if ($script:Features.ContainsKey($paramKey) -and $script:Features[$paramKey].RequiresReboot -eq $true) {
                             $feature = $script:Features[$paramKey]
-                            $rebootFeatures += "$($feature.Label)"
+                            $isUndo = $script:UndoParams.ContainsKey($paramKey)
+                            $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
+                            $rebootFeatures += "$displayLabel"
                         }
                     }
 

--- a/Scripts/Helpers/Get-RebootFeatureLabels.ps1
+++ b/Scripts/Helpers/Get-RebootFeatureLabels.ps1
@@ -1,0 +1,27 @@
+<#
+    .SYNOPSIS
+    Resolves display labels for selected features that require reboot.
+
+    .DESCRIPTION
+    Combines parameter keys from both forward and undo selections, removes duplicates,
+    and returns the feature label that should be shown to users. Undo selections use
+    UndoLabel when available.
+#>
+function Get-RebootFeatureLabels {
+    $rebootFeatureLabels = @()
+    $candidateParamKeys = (@($script:Params.Keys) + @($script:UndoParams.Keys)) | Select-Object -Unique
+
+    foreach ($paramKey in $candidateParamKeys) {
+        if ($script:Features.ContainsKey($paramKey) -and $script:Features[$paramKey].RequiresReboot -eq $true) {
+            $feature = $script:Features[$paramKey]
+            $isUndo = $script:UndoParams.ContainsKey($paramKey)
+            $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
+
+            if (-not [string]::IsNullOrWhiteSpace([string]$displayLabel)) {
+                $rebootFeatureLabels += [string]$displayLabel
+            }
+        }
+    }
+
+    return $rebootFeatureLabels
+}

--- a/Scripts/Helpers/Get-RebootFeatureLabels.ps1
+++ b/Scripts/Helpers/Get-RebootFeatureLabels.ps1
@@ -8,7 +8,7 @@
     UndoLabel when available.
 #>
 function Get-RebootFeatureLabels {
-    $rebootFeatureLabels = @()
+    $rebootFeatureLabels = [System.Collections.Generic.List[string]]::new()
     $candidateParamKeys = (@($script:Params.Keys) + @($script:UndoParams.Keys)) | Select-Object -Unique
 
     foreach ($paramKey in $candidateParamKeys) {
@@ -18,7 +18,7 @@ function Get-RebootFeatureLabels {
             $displayLabel = if ($isUndo -and $feature.UndoLabel) { $feature.UndoLabel } else { $feature.Label }
 
             if (-not [string]::IsNullOrWhiteSpace([string]$displayLabel)) {
-                $rebootFeatureLabels += [string]$displayLabel
+                [void]$rebootFeatureLabels.Add([string]$displayLabel)
             }
         }
     }

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -382,6 +382,7 @@ if (-not $script:WingetInstalled -and -not $Silent) {
 . "$PSScriptRoot/Scripts/Helpers/GenerateAppsList.ps1"
 . "$PSScriptRoot/Scripts/Helpers/GetFriendlyRegistryBackupTarget.ps1"
 . "$PSScriptRoot/Scripts/Helpers/GetFriendlyTargetUserName.ps1"
+. "$PSScriptRoot/Scripts/Helpers/Get-RebootFeatureLabels.ps1"
 . "$PSScriptRoot/Scripts/Helpers/ImportConfigToParams.ps1"
 . "$PSScriptRoot/Scripts/Helpers/GetTargetUserForAppRemoval.ps1"
 . "$PSScriptRoot/Scripts/Helpers/Get-RegFileOperations.ps1"

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -562,7 +562,11 @@ if (($controlParamsCount -eq $script:Params.Keys.Count) -or ($script:Params.Keys
 # (This also handles restore point creation if requested)
 Invoke-AllChanges
 
-RestartExplorer
+
+# Restart Explorer process unless running in Sysprep or User context
+if (-not ($script:Params.ContainsKey("Sysprep") -or $script:Params.ContainsKey("User"))) {
+    RestartExplorer
+}
 
 Write-Output ""
 Write-Output ""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Show reboot warnings for undoing features that require a restart, including undo parameter keys, by centralizing reboot label selection in the new `Get-RebootFeatureLabels` helper (using `UndoLabel` when applicable, otherwise `Label`).
- Use undo-specific labels for pending undo actions in the GUI: `Get-PendingTweakActions` now sets `Undo` action labels via `Get-UndoFeatureLabel` for the mapped feature id.
- Refactor reboot-instructions UI generation in `Show-ApplyModal` to build the reboot-required feature list directly from `Get-RebootFeatureLabels`, while preserving the existing reboot panel visibility/behavior.
- Avoid restarting Explorer when running in `Sysprep` mode or when targeting a specific `User` by dot-sourcing `Get-RebootFeatureLabels` in `Win11Debloat.ps1` and adjusting the post-`Invoke-AllChanges` restart flow; `RestartExplorer` now emits reboot warnings based on `Get-RebootFeatureLabels`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->