### PR TITLE
fix: honor cancellation during changes

### DIFF
--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -73,6 +73,11 @@ function RemoveApps {
         Remove-EdgeApp -edgeAppsInList $edgeAppsInList
     }
 
+    if ($script:CancelRequested) {
+        Write-Host ""
+        return
+    }
+
     # Check whether any winget-removed apps are still present, and report errors for each one.
     if ($wingetRemovedApps.Count -gt 0 -or $edgeAppsInList.Count -gt 0) {
         $postRemovalList = if ($script:WingetInstalled) { GetInstalledAppsViaWinget -TimeOut 10 -NonBlocking } else { $null }
@@ -122,6 +127,13 @@ function Remove-WinGetApp {
         return
     }
 
+    Invoke-NonBlocking -ScriptBlock {
+        param($appId)
+        winget uninstall --accept-source-agreements --disable-interactivity --id $appId
+    } -ArgumentList $app
+
+    if ($script:CancelRequested) { return }
+
     if ($script:Params.ContainsKey("User")) {
         Write-Host "Adding scheduled task to uninstall $app for user $(GetUserName)..."
         Set-RunOnceWingetTask -appId $app
@@ -130,11 +142,6 @@ function Remove-WinGetApp {
         Write-Host "Adding scheduled task to uninstall $app for new users..."
         Set-RunOnceWingetTask -appId $app
     }
-
-    Invoke-NonBlocking -ScriptBlock {
-        param($appId)
-        winget uninstall --accept-source-agreements --disable-interactivity --id $appId
-    } -ArgumentList $app
 }
 
 <#
@@ -159,6 +166,18 @@ function Remove-EdgeApp {
         return
     }
 
+    foreach ($edgeApp in $edgeAppsInList) {
+        if ($script:CancelRequested) { return }
+
+        Write-Host "Removing $edgeApp"
+        Invoke-NonBlocking -ScriptBlock {
+            param($appId)
+            winget uninstall --accept-source-agreements --disable-interactivity --id $appId
+        } -ArgumentList $edgeApp
+    }
+
+    if ($script:CancelRequested) { return }
+
     if ($script:Params.ContainsKey("User")) {
         Write-Host "Adding scheduled task to uninstall Microsoft Edge for user $(GetUserName)..."
         Set-RunOnceWingetTask -appId 'Microsoft.Edge'
@@ -166,14 +185,6 @@ function Remove-EdgeApp {
     elseif ($script:Params.ContainsKey("Sysprep")) {
         Write-Host "Adding scheduled task to uninstall Microsoft Edge for new users..."
         Set-RunOnceWingetTask -appId 'Microsoft.Edge'
-    }
-
-    foreach ($edgeApp in $edgeAppsInList) {
-        Write-Host "Removing $edgeApp"
-        Invoke-NonBlocking -ScriptBlock {
-            param($appId)
-            winget uninstall --accept-source-agreements --disable-interactivity --id $appId
-        } -ArgumentList $edgeApp
     }
 }
 

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -6,9 +6,8 @@
     Iterates over the provided list of app identifiers and removes each one.
     The removal method (winget vs. Appx cmdlets) is determined per-app from
     Apps.json. A scheduled task is only created when the User or Sysprep
-    parameter was passed.
-    After each winget removal, the system is checked to confirm whether the
-    app is still installed before reporting an error.
+    parameter was passed. After winget removal, the system is checked to 
+    confirm whether the app is still installed before reporting an error.
 
     .PARAMETER appsList
     An array of app package identifiers to remove (e.g. 'Microsoft.BingNews').
@@ -98,14 +97,11 @@ function RemoveApps {
 
 <#
     .SYNOPSIS
-    Uninstalls a non-Edge app via WinGet and/or schedules its removal.
+    Uninstalls an app via WinGet and/or schedules its removal.
 
     .DESCRIPTION
     Runs winget uninstall for a single app. If the User or Sysprep
     parameter was passed, also schedules removal for future logins.
-    After uninstall, the system is checked to confirm whether the app
-    is still present — winget output is not trusted on its
-    own, as it sometimes reports failure after a successful removal.
 
     .PARAMETER app
     The WinGet package ID to uninstall (e.g. 'Microsoft.BingNews').

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -8,6 +8,7 @@
     Apps.json. A scheduled task is only created when the User or Sysprep
     parameter was passed. After winget removal, the system is checked to 
     confirm whether the app is still installed before reporting an error.
+    Returns early if the CancelRequested flag is set.
 
     .PARAMETER appsList
     An array of app package identifiers to remove (e.g. 'Microsoft.BingNews').

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -5,9 +5,8 @@
     .DESCRIPTION
     Iterates over the provided list of app identifiers and removes each one.
     The removal method (winget vs. Appx cmdlets) is determined per-app from
-    Apps.json. Microsoft Edge is deferred to the end of the loop so that all
-    winget attempts run before any force-remove prompt. A scheduled task is
-    only created when the User or Sysprep parameter was passed.
+    Apps.json. A scheduled task is only created when the User or Sysprep
+    parameter was passed.
     After each winget removal, the system is checked to confirm whether the
     app is still installed before reporting an error.
 
@@ -51,15 +50,13 @@ function RemoveApps {
             & $script:ApplySubStepCallback "Removing apps ($appIndex/$appCount)" $appIndex $appCount
         }
 
-        # Microsoft Edge is handled after the loop to avoid duplicate scheduled tasks and allow fallback if winget fails
-        if ($edgeIds -contains $app) {
-            $edgeAppsInList += $app
-            continue
-        }
-
         Write-Host "Removing $app"
 
         if ((Get-AppRemovalMethod $app) -eq 'WinGet') {
+            if ($edgeIds -contains $app) {
+                $edgeAppsInList += $app
+            }
+
             Remove-WinGetApp -app $app
             $wingetRemovedApps += $app
         }
@@ -68,36 +65,31 @@ function RemoveApps {
         }
     }
 
-    # Remove Microsoft Edge
-    if ($edgeAppsInList.Count -gt 0) {
-        Remove-EdgeApp -edgeAppsInList $edgeAppsInList
-    }
-
     if ($script:CancelRequested) {
         Write-Host ""
         return
     }
 
     # Check whether any winget-removed apps are still present, and report errors for each one.
-    if ($wingetRemovedApps.Count -gt 0 -or $edgeAppsInList.Count -gt 0) {
+    if ($wingetRemovedApps.Count -gt 0) {
         $postRemovalList = if ($script:WingetInstalled) { GetInstalledAppsViaWinget -TimeOut 10 -NonBlocking } else { $null }
+        $edgeForceRemoveRequested = $false
+
         foreach ($app in $wingetRemovedApps) {
-            if (Test-AppStillInstalled -appId $app -InstalledList $postRemovalList) {
+            if (-not (Test-AppStillInstalled -appId $app -InstalledList $postRemovalList)) {
+                continue
+            }
+
+            if ($edgeAppsInList -contains $app) {
+                Write-Host "Unable to uninstall Microsoft Edge via WinGet" -ForegroundColor Red
+                if (-not $edgeForceRemoveRequested) {
+                    Request-EdgeForceRemove
+                    $edgeForceRemoveRequested = $true
+                }
+            }
+            else {
                 Write-Host "Unable to uninstall $app via WinGet" -ForegroundColor Red
             }
-        }
-
-        # Verify Edge separately (triggers its own force-remove path if still installed)
-        $edgeStillInstalled = $false
-        foreach ($edgeApp in $edgeAppsInList) {
-            if (Test-AppStillInstalled -appId $edgeApp -InstalledList $postRemovalList) {
-                $edgeStillInstalled = $true
-                break
-            }
-        }
-        if ($edgeStillInstalled) {
-            Write-Host "Unable to uninstall Microsoft Edge via WinGet" -ForegroundColor Red
-            Request-EdgeForceRemove
         }
     }
 
@@ -114,7 +106,6 @@ function RemoveApps {
     After uninstall, the system is checked to confirm whether the app
     is still present — winget output is not trusted on its
     own, as it sometimes reports failure after a successful removal.
-    Edge apps are handled separately after the main loop.
 
     .PARAMETER app
     The WinGet package ID to uninstall (e.g. 'Microsoft.BingNews').
@@ -141,50 +132,6 @@ function Remove-WinGetApp {
     elseif ($script:Params.ContainsKey("Sysprep")) {
         Write-Host "Adding scheduled task to uninstall $app for new users..."
         Set-RunOnceWingetTask -appId $app
-    }
-}
-
-<#
-    .SYNOPSIS
-    Removes Microsoft Edge via WinGet (both AppIds), with fallback to force-remove.
-
-    .DESCRIPTION
-    Edge has multiple package IDs. Runs winget uninstall for each one,
-    then creates a single scheduled task if the User or Sysprep parameter
-    was passed. After all attempts, the system is checked to confirm
-    whether Edge is still present. The force-remove prompt only
-    appears if Edge remains installed — winget false positives are ignored.
-
-    .PARAMETER edgeAppsInList
-    The Edge AppIds that appear in the removal list (one or both).
-#>
-function Remove-EdgeApp {
-    param([string[]]$edgeAppsInList)
-
-    if (-not $script:WingetInstalled) {
-        Write-Host "ERROR: WinGet is either not installed or is outdated, Microsoft Edge could not be removed" -ForegroundColor Red
-        return
-    }
-
-    foreach ($edgeApp in $edgeAppsInList) {
-        if ($script:CancelRequested) { return }
-
-        Write-Host "Removing $edgeApp"
-        Invoke-NonBlocking -ScriptBlock {
-            param($appId)
-            winget uninstall --accept-source-agreements --disable-interactivity --id $appId
-        } -ArgumentList $edgeApp
-    }
-
-    if ($script:CancelRequested) { return }
-
-    if ($script:Params.ContainsKey("User")) {
-        Write-Host "Adding scheduled task to uninstall Microsoft Edge for user $(GetUserName)..."
-        Set-RunOnceWingetTask -appId 'Microsoft.Edge'
-    }
-    elseif ($script:Params.ContainsKey("Sysprep")) {
-        Write-Host "Adding scheduled task to uninstall Microsoft Edge for new users..."
-        Set-RunOnceWingetTask -appId 'Microsoft.Edge'
     }
 }
 

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -37,7 +37,6 @@ function RemoveApps {
     $appIndex = 0
 
     $edgeIds = @('Microsoft.Edge', 'XPFFTQ037JWMHS')
-    $edgeAppsInList = @()
     $wingetRemovedApps = @()
 
     Foreach ($app in $appsList) {
@@ -52,10 +51,6 @@ function RemoveApps {
         Write-Host "Removing $app"
 
         if ((Get-AppRemovalMethod $app) -eq 'WinGet') {
-            if ($edgeIds -contains $app) {
-                $edgeAppsInList += $app
-            }
-
             Remove-WinGetApp -app $app
             $wingetRemovedApps += $app
         }
@@ -79,7 +74,7 @@ function RemoveApps {
                 continue
             }
 
-            if ($edgeAppsInList -contains $app) {
+            if ($edgeIds -contains $app) {
                 Write-Host "Unable to uninstall Microsoft Edge via WinGet" -ForegroundColor Red
                 if (-not $edgeForceRemoveRequested) {
                     Request-EdgeForceRemove

--- a/Scripts/AppRemoval/RemoveApps.ps1
+++ b/Scripts/AppRemoval/RemoveApps.ps1
@@ -114,8 +114,6 @@ function Remove-WinGetApp {
         winget uninstall --accept-source-agreements --disable-interactivity --id $appId
     } -ArgumentList $app
 
-    if ($script:CancelRequested) { return }
-
     if ($script:Params.ContainsKey("User")) {
         Write-Host "Adding scheduled task to uninstall $app for user $(GetUserName)..."
         Set-RunOnceWingetTask -appId $app

--- a/Scripts/Features/TelemetryScheduledTasks.ps1
+++ b/Scripts/Features/TelemetryScheduledTasks.ps1
@@ -40,6 +40,8 @@ function Disable-TelemetryScheduledTasks {
     $tasks = Get-TelemetryScheduledTasks
 
     foreach ($task in $tasks) {
+        if ($script:CancelRequested) { return }
+
         if ($script:Params.ContainsKey("WhatIf")) {
             Write-Host "[WhatIf] Disable Scheduled Task: $($task.Path)$($task.Name)" -ForegroundColor Cyan
             continue
@@ -92,6 +94,8 @@ function Enable-TelemetryScheduledTasks {
     $tasks = Get-TelemetryScheduledTasks
 
     foreach ($task in $tasks) {
+        if ($script:CancelRequested) { return }
+
         if ($script:Params.ContainsKey("WhatIf")) {
             Write-Host "[WhatIf] Enable Scheduled Task: $($task.Path)$($task.Name)" -ForegroundColor Cyan
             continue

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -563,6 +563,10 @@ if (($controlParamsCount -eq $script:Params.Keys.Count) -or ($script:Params.Keys
 # (This also handles restore point creation if requested)
 Invoke-AllChanges
 
+if ($script:CancelRequested) {
+    Write-Warning "Script execution was cancelled by the user. Any remaining changes were not applied."
+    AwaitKeyToExit
+}
 
 # Restart Explorer process unless running in Sysprep or User context
 if (-not ($script:Params.ContainsKey("Sysprep") -or $script:Params.ContainsKey("User"))) {


### PR DESCRIPTION
## Summary

- Stop CLI execution cleanly after a restore-point failure is cancelled, without restarting Explorer or reporting success.
- Honor cancellation between telemetry scheduled-task operations and deferred Edge uninstall steps.
- Only create target-user RunOnce uninstall tasks after the active WinGet operation completes without cancellation.

## Why

The GUI pumps events while long-running operations execute. A cancellation request could previously allow later telemetry and Edge operations to continue. In the CLI restore-point flow, declining to continue still restarted Explorer and printed a successful completion message.

## Validation

- Parsed every PowerShell script with the Windows PowerShell parser.
- Parsed all configuration JSON and checked the staged diff for whitespace errors.
- Ran mocked cancellation checks for telemetry, Edge removal, post-removal verification, and target-user RunOnce scheduling.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## PR summary

- Tightens cancellation handling across the main flow, system restore-point creation, app removal, telemetry scheduled tasks, and deferred uninstall/Edge force-remove steps.
- Stops CLI/normal execution cleanly when restore-point creation fails and the user cancels continuation (via `$script:CancelRequested`), preventing any further change phases from running.
- Makes completion behavior conditional on cancellation: after `Invoke-AllChanges`, the script warns about remaining changes and exits via `AwaitKeyToExit` when `$script:CancelRequested` is set, avoiding Explorer restart and success reporting.
- Updates `Disable-TelemetryScheduledTasks` / `Enable-TelemetryScheduledTasks` to bail out immediately during cancellation by exiting early inside per-task `foreach` loops before enable/disable logic runs.
- Reworks `RemoveApps` to process Microsoft Edge WinGet app IDs directly in the main per-app loop (removing the prior `edgeAppsInList`/deferred Edge flow), and to exit immediately on `$script:CancelRequested` before any post-removal verification or Edge force-remove prompting.
- Refines `RemoveApps` post-removal verification to run only for `wingetRemovedApps`, with per-app installed checks; for Edge it calls `Request-EdgeForceRemove` only once, and otherwise reports generic WinGet uninstall failures.
- Updates `Remove-WinGetApp` so `winget uninstall` is invoked first, and RunOnce uninstall registry tasks for the configured `User`/`Sysprep` scope are scheduled only after WinGet completes successfully without cancellation.
- Includes PowerShell cleanup (syntax/whitespace), JSON/whitespace adjustments, and mocked cancellation validation to cover the updated cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->