### PR TITLE
fix(registry-restore): reject Data/Kind mismatches before restore begins

### DIFF
--- a/Scripts/Features/RegistryBackupValidation.ps1
+++ b/Scripts/Features/RegistryBackupValidation.ps1
@@ -300,6 +300,9 @@ function Test-RegistrySnapshotAgainstAllowList {
             if (-not (Test-RegistryValueKindNameSupported -KindName $kindName)) {
                 $Errors.Add("Backup contains unsupported registry value kind '$kindName' for '$valueReference'.")
             }
+            elseif (-not (Test-RegistryValueDataMatchesKind -KindName $kindName -Data $valueSnapshot.Data)) {
+                $Errors.Add("Backup value '$valueReference' has Data that does not fit its Kind '$kindName'.")
+            }
         }
         elseif (-not [string]::IsNullOrWhiteSpace($kindName)) {
             $Errors.Add("Backup value '$valueReference' must not define Kind when Exists is false.")
@@ -443,5 +446,48 @@ function Test-RegistryValueKindNameSupported {
     }
     catch {
         return $false
+    }
+}
+
+# A corrupted or hand-edited backup can have Data that doesn't fit its declared
+# Kind (e.g. Kind=DWord with Data=4294967296, which overflows uint32). Restore-
+# RegistryValueSnapshot's Convert-RegistryValueDataFromBackup performs the same
+# narrowing casts without a try/catch, and by the time it runs the live registry
+# subtree has already been deleted (Restore-RegistryKeySnapshot deletes before
+# rewriting) - so an invalid Data/Kind pairing must be rejected here, before any
+# restore begins, not left to fail mid-restore. See #686.
+function Test-RegistryValueDataMatchesKind {
+    param(
+        [string]$KindName,
+        $Data
+    )
+
+    $kind = [System.Enum]::Parse([Microsoft.Win32.RegistryValueKind], $KindName, $true)
+
+    switch ($kind) {
+        ([Microsoft.Win32.RegistryValueKind]::DWord) {
+            try {
+                [void][uint32]$Data
+                return $true
+            }
+            catch {
+                return $false
+            }
+        }
+        ([Microsoft.Win32.RegistryValueKind]::QWord) {
+            try {
+                [void][uint64]$Data
+                return $true
+            }
+            catch {
+                return $false
+            }
+        }
+        default {
+            # String/MultiString/Binary/None conversions in Convert-RegistryValueDataFromBackup
+            # cannot throw for arbitrary Data - they stringify, array-map to strings, or fall
+            # back to an empty byte array / null.
+            return $true
+        }
     }
 }

--- a/Scripts/Features/RegistryBackupValidation.ps1
+++ b/Scripts/Features/RegistryBackupValidation.ps1
@@ -449,13 +449,25 @@ function Test-RegistryValueKindNameSupported {
     }
 }
 
-# A corrupted or hand-edited backup can have Data that doesn't fit its declared
-# Kind (e.g. Kind=DWord with Data=4294967296, which overflows uint32). Restore-
-# RegistryValueSnapshot's Convert-RegistryValueDataFromBackup performs the same
-# narrowing casts without a try/catch, and by the time it runs the live registry
-# subtree has already been deleted (Restore-RegistryKeySnapshot deletes before
-# rewriting) - so an invalid Data/Kind pairing must be rejected here, before any
-# restore begins, not left to fail mid-restore. See #686.
+<#
+    .SYNOPSIS
+        Checks whether a backed-up value's Data can be converted to its declared Kind.
+
+    .DESCRIPTION
+        A corrupted or hand-edited backup can have Data that doesn't fit its declared
+        Kind (e.g. Kind=DWord with Data=4294967296, which overflows uint32). Restore-
+        RegistryValueSnapshot's Convert-RegistryValueDataFromBackup performs the same
+        narrowing casts without a try/catch, and by the time it runs the live registry
+        subtree has already been deleted (Restore-RegistryKeySnapshot deletes before
+        rewriting) - so an invalid Data/Kind pairing must be rejected here, before any
+        restore begins, not left to fail mid-restore. See #686.
+
+    .PARAMETER KindName
+        The value's declared registry kind name (e.g. "DWord", "QWord", "String").
+
+    .PARAMETER Data
+        The value's backed-up data to validate against KindName.
+#>
 function Test-RegistryValueDataMatchesKind {
     param(
         [string]$KindName,


### PR DESCRIPTION
## Summary

Partially fixes #686 — specifically the "corrupted or hand-edited backup" trigger (case 1 in the issue). Rejects a backup whose value `Data` doesn't fit its declared `Kind` during the existing pre-restore validation pass, before `Restore-RegistryBackupState`/`Restore-RegistryKeySnapshot` ever runs.

## Root cause

`Restore-RegistryKeySnapshot` (`Scripts/Features/RestoreRegistryApplyState.ps1`) deletes the live registry subtree (`Remove-RegistrySubKeyTreeIfExists`) *before* recreating and repopulating it, with no rollback if the repopulation throws partway through. `Convert-RegistryValueDataFromBackup`'s `[uint32]`/`[uint64]` casts for `DWord`/`QWord` values throw an uncaught `OverflowException` (or invalid-cast exception) when `Data` doesn't fit the declared `Kind` — e.g. `Kind=DWord` with `Data=4294967296` (one past `uint32`'s max). Since this happens after the delete, a corrupted or hand-edited backup file turns a restore into permanent data loss instead of a clean rejection.

`Test-RegistryValueKindNameSupported` (in `Scripts/Features/RegistryBackupValidation.ps1`) already validates that a value's `Kind` *name* parses to a real enum member, but never checked whether `Data` actually fits that `Kind` — so this exact failure mode reached the destructive path completely undetected by the existing validation.

## Fix

Added `Test-RegistryValueDataMatchesKind`, called from `Test-RegistrySnapshotAgainstAllowList` right after the existing Kind-name check (only evaluated when the Kind name is already valid). It attempts the same narrowing cast `Convert-RegistryValueDataFromBackup` would perform for `DWord`/`QWord` (the only two kinds with a cast that can throw) inside a `try`/`catch`, and returns `true` unconditionally for `String`/`MultiString`/`Binary`/`None` since those conversions can't throw for arbitrary `Data`. This runs during `Test-RegistryBackupMatchesSelectedFeatures`, which is already invoked (and already throws on validation errors) *before* `Restore-RegistryBackupState` is called — so a mismatched backup is now rejected with a clear error instead of reaching the destructive restore path at all.

## Scope (intentionally not covered)

Per the issue's own disclosure, this only closes the *corrupted-backup* trigger. It does **not** attempt:
- A real rollback/atomic-replace mechanism for the delete-then-rewrite sequence itself (case 2: a runtime `SetValue` failure from `AccessDenied`/IO/permission drift mid-loop). The issue is correct that there's no atomic "replace key subtree" primitive in the `Microsoft.Win32.RegistryKey` API, so any mitigation there (temp-sibling-key staging + `reg export` rollback) is a real design decision for a maintainer to make, not something I wanted to guess at and ship as if it were a complete fix.
- The related `Invoke-RegistryOperationsFromRegFile` silent-partial-failure gap the issue flagged (only throws when *all* operations are access-denied) — noted as a maintainer follow-up, not touched here.

## Testing

This repo has no automated test suite (manual testing per `CONTRIBUTING.md`). Since the new function is pure validation logic with zero registry I/O, I verified it in an isolated PowerShell session (dot-sourcing just this file, no registry access) against 10 cases: the exact repro from the issue (`DWord`/`4294967296` → correctly rejected), the boundary-valid case (`DWord`/`4294967295` → accepted), negative values for both `DWord` and `QWord`, valid/max-valid `QWord`, and confirmed `String`/`Binary`/`MultiString` are never rejected. All 10 passed. Also ran `[System.Management.Automation.Language.Parser]::ParseFile` against the modified file to confirm no syntax errors.

## Disclosure

Prepared with AI assistance (Claude Code). I read the full restore/validation flow (`RestoreRegistryApplyState.ps1`, `RestoreRegistryBackup.ps1`, `RegistryBackupValidation.ps1`) to confirm the exact delete-before-rewrite ordering and the validation call sequence before writing this, and verified the new function's behavior directly rather than assuming it was correct.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Added an additional pre-restore validation in `Test-RegistrySnapshotAgainstAllowList` to ensure that when a backup registry value both `Exists` and declares a non-empty `Kind`, the backed-up `Data` is compatible with that `Kind`.
- Introduced `Test-RegistryValueDataMatchesKind` to parse `KindName` into `Microsoft.Win32.RegistryValueKind` and enforce narrowing conversions for `DWord` (`uint32`) and `QWord` (`uint64`), rejecting invalid or out-of-range data.
- Continues to accept arbitrary `Data` for non-throwing/non-enforced registry kinds, avoiding unnecessary rejection of legitimate backups.
- Prevents malformed/corrupted backups from reaching the destructive delete-and-rewrite restore process.
- Added comment-based help (`.SYNOPSIS`, `.DESCRIPTION`, `.PARAMETER`) for `Test-RegistryValueDataMatchesKind`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->