### PR TITLE
refactor: rename `NoRestartExplorer` parameter to `SkipExplorerRestart`

### DIFF
--- a/Scripts/Features/Invoke-RestartExplorer.ps1
+++ b/Scripts/Features/Invoke-RestartExplorer.ps1
@@ -12,8 +12,8 @@ function Invoke-RestartExplorer {
     }
 
     Write-Host "> Attempting to restart the Windows Explorer process to apply all changes..."
-    
-    if ($script:Params.ContainsKey("NoRestartExplorer")) {
+
+    if ($script:Params.ContainsKey('SkipExplorerRestart')) {
         Write-Host "Explorer process restart was skipped, please manually reboot your PC to apply all changes" -ForegroundColor Yellow
         return
     }

--- a/Scripts/GUI/Show-MainWindow.ps1
+++ b/Scripts/GUI/Show-MainWindow.ps1
@@ -777,7 +777,7 @@ function Show-MainWindow {
             }
 
             $restartExplorerCheckBox = $window.FindName('RestartExplorerCheckBox')
-            if ($restartExplorerCheckBox -and $script:Params.ContainsKey("NoRestartExplorer")) {
+            if ($restartExplorerCheckBox -and $script:Params.ContainsKey('SkipExplorerRestart')) {
                 $restartExplorerCheckBox.IsChecked = $false
                 $restartExplorerCheckBox.IsEnabled = $false
             }

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -7,7 +7,8 @@ param (
     [switch]$Sysprep,
     [string]$LogPath,
     [string]$User,
-    [switch]$NoRestartExplorer,
+    [Alias('NoRestartExplorer')]
+    [switch]$SkipExplorerRestart,
     [switch]$CreateRestorePoint,
     [switch]$RunDefaults,
     [switch]$RunDefaultsLite,

--- a/Scripts/Helpers/Import-ConfigToParams.ps1
+++ b/Scripts/Helpers/Import-ConfigToParams.ps1
@@ -82,7 +82,7 @@ function Import-ConfigToParams {
         }
 
         if ($deploymentLookup.ContainsKey('RestartExplorer') -and -not [bool]$deploymentLookup['RestartExplorer']) {
-            Add-Parameter 'NoRestartExplorer'
+            Add-Parameter 'SkipExplorerRestart'
             $importedItems++
         }
 

--- a/Tests/Import-ConfigToParams.Tests.ps1
+++ b/Tests/Import-ConfigToParams.Tests.ps1
@@ -31,7 +31,7 @@ Describe 'Import-ConfigToParams' {
             $script:Params[$featureId] | Should -BeTrue
         }
         $script:Params['CreateRestorePoint'] | Should -BeTrue
-        $script:Params['NoRestartExplorer'] | Should -BeTrue
+        $script:Params['SkipExplorerRestart'] | Should -BeTrue
         $script:Params.ContainsKey('User') | Should -BeFalse
         $script:Params.ContainsKey('AppRemovalTarget') | Should -BeFalse
     }

--- a/Tests/Resolve-UserProfilePath.Tests.ps1
+++ b/Tests/Resolve-UserProfilePath.Tests.ps1
@@ -56,10 +56,19 @@ Describe 'Test-ModernStandbySupport' {
         Mock Stop-Process {}
         $script:Params = @{ WhatIf = $true }
         Invoke-RestartExplorer
-        $script:Params = @{ NoRestartExplorer = $true }
+        $script:Params = @{ SkipExplorerRestart = $true }
         Invoke-RestartExplorer
 
         Should -Invoke Stop-Process -Times 0 -Exactly
+    }
+
+    It 'treats NoRestartExplorer as a backward-compatible alias for SkipExplorerRestart' {
+        # Verify the alias is declared on Win11Debloat.ps1's canonical parameter,
+        # so legacy callers using -NoRestartExplorer continue to work without code duplication.
+        $command = Get-Command (Join-Path $PSScriptRoot '..\Win11Debloat.ps1')
+        $skipParam = $command.Parameters['SkipExplorerRestart']
+        $skipParam | Should -Not -BeNullOrEmpty
+        $skipParam.Aliases | Should -Contain 'NoRestartExplorer'
     }
 
     It 'restarts Explorer when allowed and reports reboot-required features' {

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -5,7 +5,8 @@ param (
     [switch]$Sysprep,
     [string]$LogPath,
     [string]$User,
-    [switch]$NoRestartExplorer,
+    [Alias('NoRestartExplorer')]
+    [switch]$SkipExplorerRestart,
     [switch]$CreateRestorePoint,
     [switch]$RunDefaults,
     [switch]$RunDefaultsLite,
@@ -185,7 +186,7 @@ $script:RestoreBackupWindowSchema = Join-Path $schemasPath 'RestoreBackupWindow.
 $script:LoadAppsDetailsScriptPath = Join-Path (Join-Path $scriptsPath 'FileIO') 'Import-AppDetailsFromJson.ps1'
 $script:TestAppInWingetListScriptPath = Join-Path (Join-Path $scriptsPath 'AppRemoval') 'Test-AppInWingetList.ps1'
 
-$script:ControlParams = 'WhatIf', 'Confirm', 'Verbose', 'Debug', 'LogPath', 'Silent', 'Sysprep', 'User', 'NoRestartExplorer', 'RunDefaults', 'RunDefaultsLite', 'RunSavedSettings', 'Config', 'CLI', 'AppRemovalTarget'
+$script:ControlParams = 'WhatIf', 'Confirm', 'Verbose', 'Debug', 'LogPath', 'Silent', 'Sysprep', 'User', 'SkipExplorerRestart', 'RunDefaults', 'RunDefaultsLite', 'RunSavedSettings', 'Config', 'CLI', 'AppRemovalTarget'
 
 # Script-level variables for GUI elements
 $script:GuiWindow = $null


### PR DESCRIPTION
The old `NoRestartExplorer` parameter is kept as an alias and will continue to work, but is considered deprecated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Renamed the Explorer restart option to `-SkipExplorerRestart`.
- Preserved `-NoRestartExplorer` as a deprecated alias.
- Updated restart handling, configuration import, GUI initialization, parameter tracking, and related tests to use the new name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->