### PR TITLE
fix: force stop widget processes to prevent prompt

### DIFF
--- a/Scripts/Features/Invoke-Changes.ps1
+++ b/Scripts/Features/Invoke-Changes.ps1
@@ -73,7 +73,7 @@ function Invoke-FeatureApply {
             Write-Host "> $applyText..."
             # Stop widgets related processes before removing the app packages to prevent potential issues
             if (-not $script:Params.ContainsKey("WhatIf")) {
-                Get-Process *Widget* -ErrorAction SilentlyContinue | Stop-Process
+                Get-Process *Widget* -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
             }
 
             Remove-SelectedApps @('Microsoft.StartExperiencesApp','MicrosoftWindows.Client.WebExperience','Microsoft.WidgetsPlatformRuntime')

--- a/Tests/Invoke-Changes.Tests.ps1
+++ b/Tests/Invoke-Changes.Tests.ps1
@@ -132,6 +132,14 @@ Describe 'Invoke-FeatureApply' {
         Should -Invoke Stop-Process -Times 0 -Exactly
     }
 
+    It 'stops widget processes without a confirmation prompt' {
+        Mock Get-Process { [PSCustomObject]@{ Name = 'Widgets' } }
+
+        Invoke-FeatureApply -FeatureId 'DisableWidgets'
+
+        Should -Invoke Stop-Process -Times 1 -Exactly -ParameterFilter { $Force -and $ErrorAction -eq 'SilentlyContinue' }
+    }
+
     It 'enables the expected optional Windows features' {
         Invoke-FeatureApply -FeatureId 'EnableWindowsSandbox'
         Invoke-FeatureApply -FeatureId 'EnableWindowsSubsystemForLinux'


### PR DESCRIPTION
Addresses #712 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Force-stops widget processes while suppressing process lookup and termination errors.
- Adds test coverage ensuring widget processes stop without confirmation prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->