### PR TITLE
fix: support QWord, ExpandString and MultiString in the .reg fallback writer

### DIFF
--- a/Scripts/Helpers/Apply-RegistryRegFile.ps1
+++ b/Scripts/Helpers/Apply-RegistryRegFile.ps1
@@ -11,6 +11,10 @@ function Get-NormalizedRegistryValueName {
     return [string]$ValueName
 }
 
+<#
+    .SYNOPSIS
+        Converts a parsed .reg operation into a Name/Kind/Value set for RegistryKey.SetValue.
+#>
 function Convert-RegOperationToValueKind {
     param(
         [Parameter(Mandatory)]

--- a/Scripts/Helpers/Apply-RegistryRegFile.ps1
+++ b/Scripts/Helpers/Apply-RegistryRegFile.ps1
@@ -17,21 +17,34 @@ function Convert-RegOperationToValueKind {
         $Operation
     )
 
-    $valueName = if ([string]::IsNullOrEmpty([string]$Operation.ValueName)) { '' } else { [string]$Operation.ValueName }
+    $valueName = Get-NormalizedRegistryValueName -ValueName $Operation.ValueName
     $valueType = [string]$Operation.ValueType
     $operationKeyPath = [string]$Operation.KeyPath
 
+    # ValueType here is whatever Get-RegFileOperations parsed it as.
+    # Hex2/Hex7 are its names for REG_EXPAND_SZ/REG_MULTI_SZ, already decoded to string/string[].
     switch ($valueType) {
         'DWord' {
             $unsigned = [uint32]$Operation.ValueData
             $value = [BitConverter]::ToInt32([BitConverter]::GetBytes($unsigned), 0)
             return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::DWord; Value = $value }
         }
+        'QWord' {
+            $unsigned = [uint64]$Operation.ValueData
+            $value = [BitConverter]::ToInt64([BitConverter]::GetBytes($unsigned), 0)
+            return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::QWord; Value = $value }
+        }
         'String' {
             return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::String; Value = [string]$Operation.ValueData }
         }
+        'Hex2' {
+            return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::ExpandString; Value = [string]$Operation.ValueData }
+        }
         'Binary' {
             return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::Binary; Value = [byte[]]$Operation.ValueData }
+        }
+        'Hex7' {
+            return @{ Name = $valueName; Kind = [Microsoft.Win32.RegistryValueKind]::MultiString; Value = [string[]]@($Operation.ValueData) }
         }
         default {
             throw "Unsupported value type '$valueType' while applying reg operation for '$operationKeyPath'"

--- a/Tests/Apply-RegistryRegFile.Tests.ps1
+++ b/Tests/Apply-RegistryRegFile.Tests.ps1
@@ -9,8 +9,11 @@ BeforeAll {
 Describe 'Convert-RegOperationToValueKind' {
     It 'converts <Case> to a registry-compatible value' -ForEach @(
         @{ Case = 'an unsigned DWord'; ValueName = $null; ValueType = 'DWord'; ValueData = [uint32]::MaxValue; ExpectedName = ''; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::DWord; ExpectedValue = -1 }
+        @{ Case = 'an unsigned QWord'; ValueName = 'Big'; ValueType = 'QWord'; ValueData = [uint64]::MaxValue; ExpectedName = 'Big'; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::QWord; ExpectedValue = -1L }
         @{ Case = 'a string value'; ValueName = 'Name'; ValueType = 'String'; ValueData = 42; ExpectedName = 'Name'; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::String; ExpectedValue = '42' }
+        @{ Case = 'an expandable string value'; ValueName = 'Path'; ValueType = 'Hex2'; ValueData = 'test%PATH%'; ExpectedName = 'Path'; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::ExpandString; ExpectedValue = 'test%PATH%' }
         @{ Case = 'a binary value'; ValueName = 'Bytes'; ValueType = 'Binary'; ValueData = @(1, 255); ExpectedName = 'Bytes'; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::Binary; ExpectedValue = [byte[]](1, 255) }
+        @{ Case = 'a multi-string value'; ValueName = 'List'; ValueType = 'Hex7'; ValueData = @('a', 'b', 'c'); ExpectedName = 'List'; ExpectedKind = [Microsoft.Win32.RegistryValueKind]::MultiString; ExpectedValue = [string[]]@('a', 'b', 'c') }
     ) {
         $result = Convert-RegOperationToValueKind -Operation ([PSCustomObject]@{
             KeyPath = 'HK'; ValueName = $ValueName; ValueType = $ValueType; ValueData = $ValueData


### PR DESCRIPTION
So, I was walking a friend through the PowerShell fallback in Import-RegistryFile.ps1, using this repo as an example of when `reg import` fails and you need a backup writer. I noticed that Convert-RegOperationToValueKind only handles DWord, String and Binary, everything else throws "Unsupported value type".

It's not a rare fallback either. Import-RegistryFile.ps1 skips `reg import` entirely whenever `-User` targets someone already logged in (their hive's mounted under its own SID, not `HKEY_USERS\Default`), and it's the retry path whenever `reg import` fails. There's no shipped .reg file that uses QWord/hex(2)/hex(7) today, but the next feature that needs one would hit this silently.

I added the three missing cases, swapped a duplicated value-name normalization for the existing helper too.

@Raphire didn't spot anything pointing to this being on purpose.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Expanded `.reg` fallback registry conversion support for `QWord`, `ExpandString`, and `MultiString` values.
- Reused `Get-NormalizedRegistryValueName` for value-name normalization.
- Added test coverage for the newly supported registry value types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->