### PR TITLE
fix: update renamed store-suggestions function calls missed in refactor

### DIFF
--- a/Scripts/Features/Invoke-Changes.ps1
+++ b/Scripts/Features/Invoke-Changes.ps1
@@ -121,7 +121,7 @@ function Invoke-FeatureApply {
         'DisableStoreSearchSuggestions' {
             if ($script:Params.ContainsKey("Sysprep")) {
                 Write-Host "> Disabling Microsoft Store search suggestions in the start menu for all users..."
-                DisableStoreSearchSuggestionsForAllUsers
+                Set-StoreSearchSuggestionsDisabledForAllUsers
                 Write-Host ""
                 return
             }
@@ -159,7 +159,7 @@ function Invoke-FeatureUndo {
         'DisableStoreSearchSuggestions' {
             if ($script:Params.ContainsKey('Sysprep')) {
                 Write-Host "> Re-enabling Microsoft Store search suggestions in the start menu for all users..."
-                EnableStoreSearchSuggestionsForAllUsers
+                Set-StoreSearchSuggestionsEnabledForAllUsers
                 Write-Host ""
                 return
             }

--- a/Scripts/Features/Set-StoreSearchSuggestions.ps1
+++ b/Scripts/Features/Set-StoreSearchSuggestions.ps1
@@ -9,7 +9,7 @@
     suggestions in the start menu search pane.
 
     .EXAMPLE
-    DisableStoreSearchSuggestionsForAllUsers
+    Set-StoreSearchSuggestionsDisabledForAllUsers
 #>
 function Set-StoreSearchSuggestionsDisabledForAllUsers {
     # Get path to Store app database for all users
@@ -93,7 +93,7 @@ function Set-StoreSearchSuggestionsDisabled {
     where Store search suggestions appear in the start menu.
 
     .EXAMPLE
-    EnableStoreSearchSuggestionsForAllUsers
+    Set-StoreSearchSuggestionsEnabledForAllUsers
 #>
 function Set-StoreSearchSuggestionsEnabledForAllUsers {
     # Get path to Store app database for all users

--- a/Tests/Invoke-Changes.Tests.ps1
+++ b/Tests/Invoke-Changes.Tests.ps1
@@ -5,7 +5,7 @@ BeforeAll {
     function Enable-TelemetryScheduledTasks {}
     function Generate-AppsList { @() }
     function Get-FriendlyTargetUserName { 'current user' }
-    function EnableStoreSearchSuggestionsForAllUsers {}
+    function Set-StoreSearchSuggestionsEnabledForAllUsers {}
     function Set-StoreSearchSuggestionsEnabled { param($StoreAppsDatabase) }
     function Get-StoreAppsDatabasePathForUser { param($UserName) 'store.db' }
     function Get-UserName { 'Alice' }
@@ -16,7 +16,7 @@ BeforeAll {
     function Get-StartMenuBinPathForUser { param($UserName) 'start.bin' }
     function Replace-StartMenu { param($startMenuBinFile, $startMenuTemplate) }
     function Replace-StartMenuForAllUsers { param($startMenuTemplate) }
-    function DisableStoreSearchSuggestionsForAllUsers {}
+    function Set-StoreSearchSuggestionsDisabledForAllUsers {}
     function Set-StoreSearchSuggestionsDisabled { param($StoreAppsDatabase) }
 
     . (Join-Path $PSScriptRoot '..\Scripts\Features\Invoke-Changes.ps1')
@@ -70,7 +70,7 @@ Describe 'Invoke-FeatureApply' {
         Mock Get-UserName { 'Alice' }
         Mock Replace-StartMenu {}
         Mock Replace-StartMenuForAllUsers {}
-        Mock DisableStoreSearchSuggestionsForAllUsers {}
+        Mock Set-StoreSearchSuggestionsDisabledForAllUsers {}
         Mock Set-StoreSearchSuggestionsDisabled {}
         Mock Get-StoreAppsDatabasePathForUser { 'store.db' }
         Mock Get-Process { @() }
@@ -173,7 +173,7 @@ Describe 'Invoke-FeatureApply' {
         $script:Params = @{ Sysprep = $true }
         Invoke-FeatureApply -FeatureId 'DisableStoreSearchSuggestions'
 
-        Should -Invoke DisableStoreSearchSuggestionsForAllUsers -Times 1 -Exactly
+        Should -Invoke Set-StoreSearchSuggestionsDisabledForAllUsers -Times 1 -Exactly
         Should -Invoke Set-StoreSearchSuggestionsDisabled -Times 0 -Exactly
     }
 }
@@ -246,7 +246,7 @@ Describe 'Invoke-FeatureUndo' {
             DisableTelemetry = [PSCustomObject]@{}
             DisableStoreSearchSuggestions = [PSCustomObject]@{}
         }
-        Mock EnableStoreSearchSuggestionsForAllUsers {}
+        Mock Set-StoreSearchSuggestionsEnabledForAllUsers {}
         Mock Set-StoreSearchSuggestionsEnabled {}
         Mock Get-StoreAppsDatabasePathForUser { 'store.db' }
         Mock Get-UserName { 'Alice' }
@@ -261,7 +261,7 @@ Describe 'Invoke-FeatureUndo' {
     ) {
         $script:Params = $Params
         Invoke-FeatureUndo -FeatureId 'DisableStoreSearchSuggestions'
-        Should -Invoke EnableStoreSearchSuggestionsForAllUsers -Times $AllUsers -Exactly
+        Should -Invoke Set-StoreSearchSuggestionsEnabledForAllUsers -Times $AllUsers -Exactly
         Should -Invoke Set-StoreSearchSuggestionsEnabled -Times $CurrentUser -Exactly -ParameterFilter { $StoreAppsDatabase -eq 'store.db' }
     }
 


### PR DESCRIPTION
The approved-verbs refactor (#708) renamed the store-suggestions all-users functions to Set-StoreSearchSuggestionsDisabledForAllUsers / Set-StoreSearchSuggestionsEnabledForAllUsers, but the two call sites in Invoke-Changes.ps1 (the Sysprep apply path and the all-users undo path) still call the OLD names -- so that path now dies with 'The term DisableStoreSearchSuggestionsForAllUsers is not recognized', exactly as reported in #717. Notably the Pester suite did not catch this because Tests/Invoke-Changes.Tests.ps1's BeforeAll stubs also defined the old names, which masked the dangling calls -- the suite passed while the production path was broken. This PR updates: the two call sites in Invoke-Changes.ps1, the test stubs/mocks/assertions to the new names (so the suite now exercises the real contract), and two stale .EXAMPLE doc lines in Set-StoreSearchSuggestions.ps1. Verification: parse-clean on all three files; grep confirms zero references to the old names remain anywhere in Scripts/ or Tests/. I could not run the Pester suite locally (in-box Pester 3.4; the suite needs v5 and I avoid installing tools on this machine) -- tests.yml should exercise it here. Fixes #717

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Updated Store search-suggestions function references in apply and undo flows.
- Updated related Pester mocks, stubs, and assertions.
- Corrected stale documentation examples.
- Restores all-users Store search-suggestions functionality during Windows 11 Sysprep operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->