### PR TITLE
fix: record a missing .reg file as a failure instead of aborting the run

### DIFF
--- a/Scripts/Features/Import-RegistryFile.ps1
+++ b/Scripts/Features/Import-RegistryFile.ps1
@@ -11,11 +11,17 @@ function Import-RegistryFile {
     $regFilePath = Get-RegistryFilePathForFeature -RegistryKey $path
 
     if (-not (Test-Path $regFilePath)) {
-        $errorMessage = "Unable to find registry file: $path ($regFilePath)"
+        # Record the failure and continue with the remaining features instead of
+        # throwing: this precheck sits outside the try/catch below, so a throw here
+        # escapes Invoke-ApplyFeatures/Invoke-UndoFeatures uncaught and aborts the
+        # entire run mid-way (remaining features skipped, no failure summary) when
+        # a single .reg file is missing, e.g. quarantined by antivirus or lost to
+        # an incomplete download. A missing file is already counted and reported
+        # through RegistryImportFailures like any other failed import.
         $script:RegistryImportFailures++
-        Write-Host "Error: $errorMessage" -ForegroundColor Red
+        Write-Host "Error: Unable to find registry file: $path ($regFilePath)" -ForegroundColor Red
         Write-Host ""
-        throw $errorMessage
+        return
     }
 
     $importScript = {

--- a/Tests/Import-RegistryFile.Tests.ps1
+++ b/Tests/Import-RegistryFile.Tests.ps1
@@ -20,11 +20,23 @@ Describe 'Import-RegistryFile' {
         Mock Write-Warning {}
     }
 
-    It 'throws and increments the failure count when the registry file is missing' {
+    It 'records the failure and continues without throwing when the registry file is missing' {
         Mock Get-RegistryFilePathForFeature { Join-Path $TestDrive 'missing.reg' }
-        { Import-RegistryFile -message 'Apply' -path 'missing.reg' } | Should -Throw 'Unable to find registry file:*'
+        { Import-RegistryFile -message 'Apply' -path 'missing.reg' } | Should -Not -Throw
         $script:RegistryImportFailures | Should -Be 1
         Should -Invoke Invoke-NonBlocking -Times 0 -Exactly
+        Should -Invoke Invoke-RegistryOperationsFromRegFile -Times 0 -Exactly
+    }
+
+    It 'still imports subsequent registry files after one is missing' {
+        Mock Get-RegistryFilePathForFeature { Join-Path $TestDrive 'missing.reg' }
+        Import-RegistryFile -message 'Apply' -path 'missing.reg'
+
+        Mock Get-RegistryFilePathForFeature { $script:regPath }
+        Import-RegistryFile -message 'Apply' -path 'feature.reg'
+
+        $script:RegistryImportFailures | Should -Be 1
+        Should -Invoke Invoke-NonBlocking -Times 1 -Exactly
     }
 
     It 'uses the PowerShell writer only in WhatIf mode' {


### PR DESCRIPTION
PROBLEM: The missing-file precheck in Import-RegistryFile sits OUTSIDE the function's try/catch and throws. Nothing up the call chain (Invoke-FeatureApply -> Invoke-ApplyFeatures -> Invoke-AllChanges -> the CLI top level) catches it, so ONE missing .reg file aborts the whole run mid-way: the remaining selected features are silently skipped, Explorer is not restarted, and the 'N registry import change(s) failed' summary never prints -- the user is left with a half-applied system and a raw exception. This is inconsistent with an inline import failure, which is caught, counted via RegistryImportFailures, and lets the run continue. Realistic trigger: a .reg payload quarantined by antivirus (AV interference with this repo's files is well documented in past issues) or an incomplete download/extraction -- the startup integrity check only verifies the Regfiles DIRECTORY exists, not individual files. FIX: record the failure through RegistryImportFailures and continue, matching the existing inline-failure behavior. The failure still shows in red inline and in the end-of-run summary. This also composes with #613: once its rollback lands, a missing file bumping the counter triggers rollback there consistently. TESTS: updated the spec that pinned the old throw behavior ('throws and increments...' -> 'records the failure and continues...') and added a case asserting subsequent imports still run after a missing file. Parse-clean on both files; I could not run Pester locally (in-box 3.4, suite needs v5, and I avoid installing tools on this machine) -- tests.yml should exercise it on this PR. Found during a code audit of the registry-apply path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Updated `Import-RegistryFile` to handle missing computed `.reg` files by incrementing `RegistryImportFailures`, printing a red “unable to find registry file” error (including the relevant paths), and returning early instead of throwing—allowing subsequent feature/registry imports to continue.
- Updated `Import-RegistryFile.Tests.ps1` so the missing-file case asserts `Import-RegistryFile` does **not** throw, increments the failure counter to `1`, and does not call `Invoke-NonBlocking` or `Invoke-RegistryOperationsFromRegFile`.
- Added test coverage confirming that after a missing `.reg` file increments `RegistryImportFailures`, a subsequent valid registry import proceeds, keeps the failure counter at `1`, and calls `Invoke-NonBlocking` exactly once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->