### PR TITLE
fix: remove Mark-of-the-Web from script files at startup

### DIFF
--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -116,20 +116,27 @@ if ($PSVersionTable.PSEdition -eq 'Core') {
 
 # Remove the Mark-of-the-Web (Zone.Identifier) from the PowerShell script files so they
 # dot-source without per-file security prompts. The stream is added when the ZIP is
-# downloaded with a browser and extracted with Explorer, and a Group-Policy-scoped
-# execution policy overrides the -ExecutionPolicy Bypass that Run.bat passes, so launcher
-# flags alone cannot prevent the prompts. Only run when this file itself is still marked
-# (skips the recursive sweep on every normal launch once the folder is already clean) and
-# never in -WhatIf mode. Only script/module files are unblocked -- other file types are not
-# affected by the mark and keep their zone information. See issue #720.
+# downloaded with a browser and extracted with Explorer, and -ExecutionPolicy Bypass (Run.bat)
+# sets only the Process scope, which the MachinePolicy/UserPolicy scopes (Group Policy) outrank
+# -- so this can only matter when one of those two is actually set; for everyone else Bypass
+# already wins and this whole block, including the cheap self-mark check below, is skipped.
+# Never runs in -WhatIf mode. Only run when this file itself is still marked (skips the
+# recursive sweep on every normal launch once the folder is already clean). Only script/module
+# files are unblocked -- other file types are not affected by the mark and keep their zone
+# information. See issue #720.
 if (-not $WhatIfPreference) {
-    $selfBlocked = [bool](Get-Item -LiteralPath $PSCommandPath -Stream * -ErrorAction SilentlyContinue |
-        Where-Object { $_.Stream -eq 'Zone.Identifier' })
+    $gpoExecutionPolicySet = (Get-ExecutionPolicy -Scope MachinePolicy) -ne 'Undefined' -or
+        (Get-ExecutionPolicy -Scope UserPolicy) -ne 'Undefined'
 
-    if ($selfBlocked) {
-        Get-ChildItem -Path $PSScriptRoot -Recurse -File |
-            Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
-            Unblock-File -ErrorAction SilentlyContinue
+    if ($gpoExecutionPolicySet) {
+        $selfBlocked = [bool](Get-Item -LiteralPath $PSCommandPath -Stream * -ErrorAction SilentlyContinue |
+            Where-Object { $_.Stream -eq 'Zone.Identifier' })
+
+        if ($selfBlocked) {
+            Get-ChildItem -Path $PSScriptRoot -Recurse -File |
+                Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
+                Unblock-File -ErrorAction SilentlyContinue
+        }
     }
 }
 

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -118,11 +118,20 @@ if ($PSVersionTable.PSEdition -eq 'Core') {
 # dot-source without per-file security prompts. The stream is added when the ZIP is
 # downloaded with a browser and extracted with Explorer, and a Group-Policy-scoped
 # execution policy overrides the -ExecutionPolicy Bypass that Run.bat passes, so launcher
-# flags alone cannot prevent the prompts. Only script/module files are unblocked -- other
-# file types are not affected by the mark and keep their zone information. See issue #720.
-Get-ChildItem -Path $PSScriptRoot -Recurse -File |
-    Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
-    Unblock-File -ErrorAction SilentlyContinue
+# flags alone cannot prevent the prompts. Only run when this file itself is still marked
+# (skips the recursive sweep on every normal launch once the folder is already clean) and
+# never in -WhatIf mode. Only script/module files are unblocked -- other file types are not
+# affected by the mark and keep their zone information. See issue #720.
+if (-not $WhatIfPreference) {
+    $selfBlocked = [bool](Get-Item -LiteralPath $PSCommandPath -Stream * -ErrorAction SilentlyContinue |
+        Where-Object { $_.Stream -eq 'Zone.Identifier' })
+
+    if ($selfBlocked) {
+        Get-ChildItem -Path $PSScriptRoot -Recurse -File |
+            Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
+            Unblock-File -ErrorAction SilentlyContinue
+    }
+}
 
 # Check if script is running as administrator
 $isAdmin = ([Security.Principal.WindowsPrincipal] `

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -114,6 +114,13 @@ if ($PSVersionTable.PSEdition -eq 'Core') {
     exit 1
 }
 
+# Remove the Mark-of-the-Web (Zone.Identifier) from all files in the script folder so the
+# dot-sourced scripts load without per-file security prompts. The stream is added when the
+# ZIP is downloaded with a browser and extracted with Explorer, and a Group-Policy-scoped
+# execution policy overrides the -ExecutionPolicy Bypass that Run.bat passes, so launcher
+# flags alone cannot prevent the prompts. See issue #720.
+Get-ChildItem -Path $PSScriptRoot -Recurse -File | Unblock-File -ErrorAction SilentlyContinue
+
 # Check if script is running as administrator
 $isAdmin = ([Security.Principal.WindowsPrincipal] `
     [Security.Principal.WindowsIdentity]::GetCurrent()

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -114,12 +114,15 @@ if ($PSVersionTable.PSEdition -eq 'Core') {
     exit 1
 }
 
-# Remove the Mark-of-the-Web (Zone.Identifier) from all files in the script folder so the
-# dot-sourced scripts load without per-file security prompts. The stream is added when the
-# ZIP is downloaded with a browser and extracted with Explorer, and a Group-Policy-scoped
+# Remove the Mark-of-the-Web (Zone.Identifier) from the PowerShell script files so they
+# dot-source without per-file security prompts. The stream is added when the ZIP is
+# downloaded with a browser and extracted with Explorer, and a Group-Policy-scoped
 # execution policy overrides the -ExecutionPolicy Bypass that Run.bat passes, so launcher
-# flags alone cannot prevent the prompts. See issue #720.
-Get-ChildItem -Path $PSScriptRoot -Recurse -File | Unblock-File -ErrorAction SilentlyContinue
+# flags alone cannot prevent the prompts. Only script/module files are unblocked -- other
+# file types are not affected by the mark and keep their zone information. See issue #720.
+Get-ChildItem -Path $PSScriptRoot -Recurse -File |
+    Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
+    Unblock-File -ErrorAction SilentlyContinue
 
 # Check if script is running as administrator
 $isAdmin = ([Security.Principal.WindowsPrincipal] `

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -114,32 +114,6 @@ if ($PSVersionTable.PSEdition -eq 'Core') {
     exit 1
 }
 
-# Remove the Mark-of-the-Web (Zone.Identifier) from the PowerShell script files so they
-# dot-source without per-file security prompts. The stream is added when the ZIP is
-# downloaded with a browser and extracted with Explorer, and -ExecutionPolicy Bypass (Run.bat)
-# sets only the Process scope, which the MachinePolicy/UserPolicy scopes (Group Policy) outrank
-# -- so this can only matter when one of those two is actually set; for everyone else Bypass
-# already wins and this whole block, including the cheap self-mark check below, is skipped.
-# Never runs in -WhatIf mode. Only run when this file itself is still marked (skips the
-# recursive sweep on every normal launch once the folder is already clean). Only script/module
-# files are unblocked -- other file types are not affected by the mark and keep their zone
-# information. See issue #720.
-if (-not $WhatIfPreference) {
-    $gpoExecutionPolicySet = (Get-ExecutionPolicy -Scope MachinePolicy) -ne 'Undefined' -or
-        (Get-ExecutionPolicy -Scope UserPolicy) -ne 'Undefined'
-
-    if ($gpoExecutionPolicySet) {
-        $selfBlocked = [bool](Get-Item -LiteralPath $PSCommandPath -Stream * -ErrorAction SilentlyContinue |
-            Where-Object { $_.Stream -eq 'Zone.Identifier' })
-
-        if ($selfBlocked) {
-            Get-ChildItem -Path $PSScriptRoot -Recurse -File |
-                Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
-                Unblock-File -ErrorAction SilentlyContinue
-        }
-    }
-}
-
 # Check if script is running as administrator
 $isAdmin = ([Security.Principal.WindowsPrincipal] `
     [Security.Principal.WindowsIdentity]::GetCurrent()
@@ -267,6 +241,37 @@ if ($LogPath -and (Test-Path $LogPath)) {
 }
 else {
     Start-Transcript -Path $script:DefaultLogPath -Append -IncludeInvocationHeader -Force | Out-Null
+}
+
+# When Group Policy overrides Run.bat's Process-scope Bypass, marked PowerShell source files
+# can prompt as they are dot-sourced. Outside -WhatIf, remove Mark-of-the-Web only from marked
+# .ps1, .psm1, and .psd1 files under Scripts; leave all other downloaded files untouched.
+# See issue #720.
+if (-not $WhatIfPreference) {
+    $gpoExecutionPolicySet = (Get-ExecutionPolicy -Scope MachinePolicy) -ne 'Undefined' -or
+        (Get-ExecutionPolicy -Scope UserPolicy) -ne 'Undefined'
+
+    if ($gpoExecutionPolicySet) {
+        $markedScriptFiles = @(Get-ChildItem -LiteralPath $scriptsPath -Recurse -File |
+            Where-Object { $_.Extension -in '.ps1', '.psm1', '.psd1' } |
+            Where-Object {
+                Get-Item -LiteralPath $_.FullName -Stream * -ErrorAction SilentlyContinue |
+                    Where-Object { $_.Stream -eq 'Zone.Identifier' }
+            })
+
+        if ($markedScriptFiles.Count -gt 0) {
+            Write-Host "Unblocking $($markedScriptFiles.Count) PowerShell file(s)..."
+            $unblockErrors = @()
+            $markedScriptFiles | Unblock-File -ErrorAction SilentlyContinue -ErrorVariable +unblockErrors
+
+            if ($unblockErrors.Count -gt 0) {
+                Write-Warning "Failed to unblock $($unblockErrors.Count) PowerShell file(s)."
+            }
+            else {
+                Write-Host "All files were unblocked successfully."
+            }
+        }
+    }
 }
 
 # Check if the device is domain-joined and warn the user (Group Policy may override changes)


### PR DESCRIPTION
PROBLEM: Downloading the release ZIP with a browser and extracting it with Explorer stamps every file with the Zone.Identifier (Mark-of-the-Web) stream. Under a RemoteSigned-or-stricter effective execution policy, every dot-sourced .ps1 then triggers a per-file security prompt or is blocked outright -- breaking or interrupting the GUI load (#720). Critically, the reporter confirmed (via Get-ExecutionPolicy -List) an Unrestricted policy at MachinePolicy scope on their machine -- and a Group-Policy-scoped policy OVERRIDES the -ExecutionPolicy Bypass that Run.bat passes, so no launcher flag can prevent the prompts. The only fix that works regardless of policy scope is removing the stream itself. FIX: one line at startup (after the PowerShell 7 guard, before the admin check, so it runs before any dot-sourcing in both the non-elevated and relaunched-elevated process): Get-ChildItem -Path PSScriptRoot -Recurse -File piped to Unblock-File with SilentlyContinue. Unblock-File deletes the Zone.Identifier alternate data stream; on unmarked files it is a no-op, and errors (e.g. exotic ACLs) are suppressed so the line can never break startup. VERIFICATION: reproduced the full cycle non-destructively on Windows PowerShell 5.1 (5.1.26100): created a .ps1, stamped it with a real Zone.Identifier stream (ZoneId=3), confirmed dot-sourcing it in a RemoteSigned process is blocked, ran the exact Get-ChildItem/Unblock-File line from this PR, confirmed the stream is gone, and confirmed the same dot-source then loads cleanly. Parse-clean. The reporter on #720 has offered to test this change on the affected machine (GPO-scoped policy), which covers the scenario I cannot reproduce locally. NOTE: this addresses the failure class at the code level; the README suggestion from #720 remains complementary if you also want the docs note. Fixes #720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Add startup cleanup for `Zone.Identifier` streams on `.ps1`, `.psm1`, and `.psd1` files.
- Run cleanup only when the main script is marked and `-WhatIf` is not active.
- Suppress cleanup errors so startup continues.
- Preserve Mark-of-the-Web data for non-PowerShell files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->