### PR TITLE
Security hardening: launcher TOCTOU fix and safe force-Edge removal

### DIFF
--- a/Scripts/AppRemoval/Invoke-ForceRemoveEdge.ps1
+++ b/Scripts/AppRemoval/Invoke-ForceRemoveEdge.ps1
@@ -49,10 +49,18 @@ function Invoke-ForceRemoveEdge {
 
         $uninstallArgs = ($uninstallArgs + ' --force-uninstall').Trim()
 
-        Invoke-NonBlocking -ScriptBlock {
+        $uninstallExitCode = Invoke-NonBlocking -ScriptBlock {
             param($exe, $arguments)
-            Start-Process -FilePath $exe -ArgumentList $arguments -WindowStyle Hidden -Wait
+            $uninstallProcess = Start-Process -FilePath $exe -ArgumentList $arguments -WindowStyle Hidden -Wait -PassThru
+            return $uninstallProcess.ExitCode
         } -ArgumentList $uninstallExe, $uninstallArgs
+
+        # Don't clean up shortcuts and autostart entries when the uninstaller failed,
+        # Edge is still installed in that case
+        if ($null -ne $uninstallExitCode -and $uninstallExitCode -ne 0) {
+            Write-Host "Unable to forcefully uninstall Microsoft Edge, the uninstaller failed with exit code $uninstallExitCode" -ForegroundColor Red
+            return
+        }
 
         Write-Host "Removing leftover files..."
 

--- a/Scripts/AppRemoval/Invoke-ForceRemoveEdge.ps1
+++ b/Scripts/AppRemoval/Invoke-ForceRemoveEdge.ps1
@@ -7,22 +7,52 @@ function Invoke-ForceRemoveEdge {
 
     $regView = [Microsoft.Win32.RegistryView]::Registry32
     $hklm = [Microsoft.Win32.RegistryKey]::OpenBaseKey([Microsoft.Win32.RegistryHive]::LocalMachine, $regView)
+
+    # Locate the uninstaller first, before making any changes to the system
+    $uninstallRegKey = $hklm.OpenSubKey('SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge')
+    $uninstallString = if ($null -ne $uninstallRegKey) { [string]$uninstallRegKey.GetValue('UninstallString') } else { $null }
+
+    if ([string]::IsNullOrWhiteSpace($uninstallString)) {
+        Write-Host "Unable to forcefully uninstall Microsoft Edge, uninstaller could not be found" -ForegroundColor Red
+        return
+    }
+
     $hklm.CreateSubKey('SOFTWARE\Microsoft\EdgeUpdateDev').SetValue('AllowUninstall', '')
 
     # Create stub (This somehow allows uninstalling Edge)
+    # Only create it when the folder doesn't exist yet: on Windows 10 this path is the REAL
+    # legacy Edge (EdgeHTML) system package, which must never be created over or deleted.
+    # The stub is only removed later if this script created it.
     $edgeStub = "$env:SystemRoot\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe"
-    New-Item $edgeStub -ItemType Directory | Out-Null
-    New-Item "$edgeStub\MicrosoftEdge.exe" | Out-Null
+    $stubCreatedByScript = $false
 
-    # Remove edge
-    $uninstallRegKey = $hklm.OpenSubKey('SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Edge')
-    if ($null -ne $uninstallRegKey) {
+    if (-not (Test-Path -LiteralPath $edgeStub)) {
+        New-Item $edgeStub -ItemType Directory | Out-Null
+        New-Item "$edgeStub\MicrosoftEdge.exe" | Out-Null
+        $stubCreatedByScript = $true
+    }
+
+    try {
         Write-Host "Running uninstaller..."
-        $uninstallString = $uninstallRegKey.GetValue('UninstallString') + ' --force-uninstall'
+
+        # Split the UninstallString into executable and arguments and invoke it directly,
+        # instead of interpolating the raw registry value into a cmd.exe command line
+        if ($uninstallString -match '^\s*"(?<exe>[^"]+)"\s*(?<args>.*)$') {
+            $uninstallExe = $Matches.exe
+            $uninstallArgs = $Matches.args
+        }
+        else {
+            $splitParts = $uninstallString.Trim() -split '\s+', 2
+            $uninstallExe = $splitParts[0]
+            $uninstallArgs = if ($splitParts.Count -gt 1) { $splitParts[1] } else { '' }
+        }
+
+        $uninstallArgs = ($uninstallArgs + ' --force-uninstall').Trim()
+
         Invoke-NonBlocking -ScriptBlock {
-            param($cmd)
-            Start-Process cmd.exe "/c $cmd" -WindowStyle Hidden -Wait
-        } -ArgumentList $uninstallString
+            param($exe, $arguments)
+            Start-Process -FilePath $exe -ArgumentList $arguments -WindowStyle Hidden -Wait
+        } -ArgumentList $uninstallExe, $uninstallArgs
 
         Write-Host "Removing leftover files..."
 
@@ -32,8 +62,7 @@ function Invoke-ForceRemoveEdge {
             "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Microsoft Edge.lnk",
             "$env:APPDATA\Microsoft\Internet Explorer\Quick Launch\User Pinned\TaskBar\Tombstones\Microsoft Edge.lnk",
             "$env:PUBLIC\Desktop\Microsoft Edge.lnk",
-            "$env:USERPROFILE\Desktop\Microsoft Edge.lnk",
-            "$edgeStub"
+            "$env:USERPROFILE\Desktop\Microsoft Edge.lnk"
         )
 
         foreach ($path in $edgePaths) {
@@ -53,7 +82,11 @@ function Invoke-ForceRemoveEdge {
 
         Write-Host "Microsoft Edge was uninstalled"
     }
-    else {
-        Write-Host "Unable to forcefully uninstall Microsoft Edge, uninstaller could not be found" -ForegroundColor Red
+    finally {
+        # Always remove the stub if this script created it, even when the uninstall failed,
+        # so no fake MicrosoftEdge.exe is left behind in SystemApps
+        if ($stubCreatedByScript -and (Test-Path -LiteralPath $edgeStub)) {
+            Remove-Item -Path $edgeStub -Force -Recurse -ErrorAction SilentlyContinue
+        }
     }
 }

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -119,32 +119,10 @@ Write-Output "------------------------------------------------------------------
 Write-Output " Win11Debloat Script"
 Write-Output "-------------------------------------------------------------------------------------------"
 
-# Use a unique archive name per invocation so concurrent launcher runs cannot overwrite each other's download
-$tempArchivePath = Join-Path $env:TEMP "win11debloat_$([guid]::NewGuid().ToString('N')).zip"
-
-# Download Win11Debloat from GitHub as a zip archive.
-try {
-    if ($Dev) {
-        Write-Output "> Downloading development version of Win11Debloat..."
-        $sourceUri = "https://github.com/Raphire/Win11Debloat/archive/refs/heads/master.zip"
-    } else {
-        Write-Output "> Downloading Win11Debloat..."
-        $sourceUri = (Invoke-RestMethod https://api.github.com/repos/Raphire/Win11Debloat/releases/latest).zipball_url
-    }
-    Invoke-RestMethod $sourceUri -OutFile $tempArchivePath
-}
-catch {
-    Write-Host "Error: Unable to fetch required files from GitHub. Please check your internet connection and try again." -ForegroundColor Red
-    Write-Output ""
-    Write-Output "Press enter to exit..."
-    Read-Host | Out-Null
-    Exit
-}
-
-# Record the archive hash immediately after download. The hash is passed to the elevated
-# process, which re-verifies the archive after copying it into a protected directory. This
-# prevents a non-elevated process from swapping the files between download and elevated execution.
-$archiveHash = (Get-FileHash -LiteralPath $tempArchivePath -Algorithm SHA256).Hash
+# The archive is downloaded by the elevated bootstrap directly into an Administrators/SYSTEM-only
+# staging directory, never into a location a non-elevated process can modify. A pre-elevation
+# download to %TEMP% would let an attacker swap the archive before use, and hashing it in the
+# non-elevated context would only fingerprint the attacker's file, so both are avoided entirely.
 
 # Make list of arguments to pass on to the script (exclude the -Dev switch, which only affects this launcher)
 $arguments = $($PSBoundParameters.GetEnumerator() | Where-Object { $_.Key -ne 'Dev' } | ForEach-Object {
@@ -191,16 +169,21 @@ function Format-EmbeddedLiteral([string]$Value) {
     return "'" + ($Value -replace "'", "''") + "'"
 }
 
-# The bootstrap below runs elevated. It stages, verifies and executes the script inside a
-# directory that only Administrators and SYSTEM can write to, so that unpacked script files
-# cannot be tampered with by non-elevated processes before or during elevated execution.
-$bootstrapTemplate = @'
-$ErrorActionPreference = 'Stop'
-$archivePath = __ARCHIVE__
-$expectedHash = __HASH__
-$scriptArgs = __ARGS__
-$debloatWindowStyle = __WINDOWSTYLE__
+# The bootstrap below runs elevated. It downloads, unpacks and executes the script inside a
+# directory that only Administrators and SYSTEM can write to, so that the archive and the unpacked
+# script files cannot be tampered with by non-elevated processes before or during elevated execution.
+#
+# Inputs are injected as a header of escaped single-quoted literals (built via Format-EmbeddedLiteral)
+# concatenated ahead of the static body. This avoids placeholder-token substitution, where an input
+# value that happened to contain a token string could be corrupted by a later replacement pass.
+$bootstrapHeader = @"
+`$ErrorActionPreference = 'Stop'
+`$isDev = $(if ($Dev) { '$true' } else { '$false' })
+`$scriptArgs = $(Format-EmbeddedLiteral ($arguments -join ' '))
+`$debloatWindowStyle = $(Format-EmbeddedLiteral $windowStyle)
+"@
 
+$bootstrapBody = @'
 try {
     # Serialize concurrent launcher invocations: the staging directory and the Config,
     # Logs and Backups folders inside it are shared between runs
@@ -274,14 +257,23 @@ try {
             throw "Staging directory '$stagingRoot' failed post-securing verification and may have been tampered with. Aborting for safety."
         }
 
-        # Copy the downloaded archive into the protected directory, then verify its integrity
+        # Download the archive over TLS directly into the protected directory. Because only
+        # Administrators and SYSTEM can write here, the archive cannot be swapped between download
+        # and use, so the TLS-authenticated GitHub download is the integrity boundary.
         $stagedArchive = Join-Path $stagingRoot 'win11debloat.zip'
-        Copy-Item -LiteralPath $archivePath -Destination $stagedArchive -Force
-
-        $actualHash = (Get-FileHash -LiteralPath $stagedArchive -Algorithm SHA256).Hash
-        if ($actualHash -ne $expectedHash) {
-            Remove-Item -LiteralPath $stagedArchive -Force
-            throw "Integrity check of the downloaded Win11Debloat archive failed. The file was modified after download, aborting for safety. (expected $expectedHash but got $actualHash)"
+        try {
+            if ($isDev) {
+                Write-Output "> Downloading development version of Win11Debloat..."
+                $sourceUri = "https://github.com/Raphire/Win11Debloat/archive/refs/heads/master.zip"
+            }
+            else {
+                Write-Output "> Downloading Win11Debloat..."
+                $sourceUri = (Invoke-RestMethod https://api.github.com/repos/Raphire/Win11Debloat/releases/latest).zipball_url
+            }
+            Invoke-RestMethod $sourceUri -OutFile $stagedArchive
+        }
+        catch {
+            throw "Unable to fetch required files from GitHub. Please check your internet connection and try again. ($($_.Exception.Message))"
         }
 
         # One-time migration of configs, logs and backups from the old temp folder location
@@ -380,15 +372,11 @@ catch {
 }
 '@
 
-$bootstrap = $bootstrapTemplate.
-    Replace('__ARCHIVE__', (Format-EmbeddedLiteral $tempArchivePath)).
-    Replace('__HASH__', (Format-EmbeddedLiteral $archiveHash)).
-    Replace('__ARGS__', (Format-EmbeddedLiteral ($arguments -join ' '))).
-    Replace('__WINDOWSTYLE__', (Format-EmbeddedLiteral $windowStyle))
+$bootstrap = $bootstrapHeader + "`n" + $bootstrapBody
 
 $encodedBootstrap = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($bootstrap))
 
-# Elevate and run the bootstrap, which verifies, unpacks and launches Win11Debloat
+# Elevate and run the bootstrap, which downloads, unpacks and launches Win11Debloat
 $elevatedProcess = Start-Process powershell.exe -PassThru -Verb RunAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encodedBootstrap"
 
 # Wait for the process to finish before continuing
@@ -398,12 +386,9 @@ if ($null -ne $elevatedProcess) {
     $bootstrapExitCode = $elevatedProcess.ExitCode
 }
 
-# Remove the downloaded archive from the user temp folder
-Remove-Item -LiteralPath $tempArchivePath -Force -ErrorAction SilentlyContinue
-
 Write-Output ""
 
-# Propagate a bootstrap failure (integrity, extraction, or script failure) as a nonzero exit code
+# Propagate a bootstrap failure (download, integrity, extraction, or script failure) as a nonzero exit code
 if ($bootstrapExitCode -ne 0) {
     Exit $bootstrapExitCode
 }

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -220,8 +220,22 @@ try {
         $programDataPath = [Environment]::GetFolderPath([Environment+SpecialFolder]::CommonApplicationData)
         $stagingRoot = Join-Path $programDataPath 'Win11Debloat'
 
-        # Refuse to follow a reparse point (junction/symlink) planted at the staging path.
-        # Delete the link entry itself without recursing into its target.
+        $adminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
+        $systemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
+        $trustedOwnerSids = @($adminSid.Value, $systemSid.Value)
+
+        # Secure the staging directory against a staging-path swap (TOCTOU) by a non-elevated
+        # process. %ProgramData% is world-writable at the root, so an attacker could pre-plant a
+        # junction or a directory they own at this path. We close that as follows:
+        #   1. Reject and delete any reparse point (junction/symlink) at the path, without
+        #      following it into its target.
+        #   2. Refuse to adopt an existing real directory that is not already owned by
+        #      Administrators or SYSTEM - a non-elevated user's pre-created folder is owned by
+        #      that user, so a non-trusted owner means the directory is hostile.
+        #   3. Create the directory when absent and apply an Administrators/SYSTEM-only ACL.
+        #   4. Re-verify after the ACL is in place: because the ACL now blocks non-elevated
+        #      writers, a directory that is still a non-reparse, admin-owned directory here
+        #      could not have been swapped by an attacker during the securing sequence.
         $existingStaging = Get-Item -LiteralPath $stagingRoot -Force -ErrorAction SilentlyContinue
         if ($existingStaging -and ($existingStaging.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
             if ($existingStaging.Attributes -band [System.IO.FileAttributes]::Directory) {
@@ -233,14 +247,17 @@ try {
             $existingStaging = $null
         }
 
-        if (-not $existingStaging) {
+        if ($existingStaging) {
+            $existingOwner = $existingStaging.GetAccessControl().GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+            if ($trustedOwnerSids -notcontains $existingOwner) {
+                throw "Refusing to use staging directory '$stagingRoot': it already exists but is not owned by Administrators or SYSTEM (owner SID: $existingOwner). A non-elevated process may have created it. Remove it manually and re-run."
+            }
+        }
+        else {
             New-Item -ItemType Directory -Path $stagingRoot | Out-Null
         }
 
         # Take ownership of the staging directory and restrict it to Administrators and SYSTEM.
-        # This also neutralizes a directory pre-created by a non-elevated process.
-        $adminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
-        $systemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
         $acl = New-Object System.Security.AccessControl.DirectorySecurity
         $acl.SetOwner($adminSid)
         $acl.SetAccessRuleProtection($true, $false)
@@ -248,6 +265,14 @@ try {
             $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, 'ContainerInherit,ObjectInherit', 'None', 'Allow')))
         }
         Set-Acl -Path $stagingRoot -AclObject $acl
+
+        # Post-securing verification: confirm the ACL landed on the intended object and not a
+        # reparse point swapped in during the sequence above
+        $securedStaging = Get-Item -LiteralPath $stagingRoot -Force
+        $securedOwner = $securedStaging.GetAccessControl().GetOwner([System.Security.Principal.SecurityIdentifier]).Value
+        if (($securedStaging.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -or ($trustedOwnerSids -notcontains $securedOwner)) {
+            throw "Staging directory '$stagingRoot' failed post-securing verification and may have been tampered with. Aborting for safety."
+        }
 
         # Copy the downloaded archive into the protected directory, then verify its integrity
         $stagedArchive = Join-Path $stagingRoot 'win11debloat.zip'
@@ -367,11 +392,18 @@ $encodedBootstrap = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.Ge
 $elevatedProcess = Start-Process powershell.exe -PassThru -Verb RunAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encodedBootstrap"
 
 # Wait for the process to finish before continuing
+$bootstrapExitCode = 0
 if ($null -ne $elevatedProcess) {
     $elevatedProcess.WaitForExit()
+    $bootstrapExitCode = $elevatedProcess.ExitCode
 }
 
 # Remove the downloaded archive from the user temp folder
 Remove-Item -LiteralPath $tempArchivePath -Force -ErrorAction SilentlyContinue
 
 Write-Output ""
+
+# Propagate a bootstrap failure (integrity, extraction, or script failure) as a nonzero exit code
+if ($bootstrapExitCode -ne 0) {
+    Exit $bootstrapExitCode
+}

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -119,7 +119,8 @@ Write-Output "------------------------------------------------------------------
 Write-Output " Win11Debloat Script"
 Write-Output "-------------------------------------------------------------------------------------------"
 
-$tempArchivePath = Join-Path $env:TEMP 'win11debloat.zip'
+# Use a unique archive name per invocation so concurrent launcher runs cannot overwrite each other's download
+$tempArchivePath = Join-Path $env:TEMP "win11debloat_$([guid]::NewGuid().ToString('N')).zip"
 
 # Download Win11Debloat from GitHub as a zip archive.
 try {
@@ -172,7 +173,20 @@ if ($PSVersionTable.PSVersion.Major -ge 7) {
     $env:PSModulePath = $NewPSModulePath -join ';'
 }
 
-# Escapes a value for embedding inside a single-quoted PowerShell string literal
+<#
+    .SYNOPSIS
+        Escapes a value for safe embedding inside a single-quoted PowerShell string literal.
+
+    .DESCRIPTION
+        Doubles any embedded single quotes and wraps the result in single quotes, so the
+        value is always treated as a literal string when spliced into generated script text.
+
+    .PARAMETER Value
+        The string value to escape and wrap.
+
+    .OUTPUTS
+        System.String. The single-quoted, escaped string literal.
+#>
 function Format-EmbeddedLiteral([string]$Value) {
     return "'" + ($Value -replace "'", "''") + "'"
 }
@@ -188,104 +202,149 @@ $scriptArgs = __ARGS__
 $debloatWindowStyle = __WINDOWSTYLE__
 
 try {
-    $stagingRoot = Join-Path $env:ProgramData 'Win11Debloat'
-
-    if (-not (Test-Path -LiteralPath $stagingRoot)) {
-        New-Item -ItemType Directory -Path $stagingRoot | Out-Null
+    # Serialize concurrent launcher invocations: the staging directory and the Config,
+    # Logs and Backups folders inside it are shared between runs
+    $bootstrapMutex = New-Object System.Threading.Mutex($false, 'Global\Win11DebloatBootstrap')
+    $mutexAcquired = $false
+    try {
+        $mutexAcquired = $bootstrapMutex.WaitOne()
+    }
+    catch [System.Threading.AbandonedMutexException] {
+        # A previous holder exited without releasing; ownership is still acquired
+        $mutexAcquired = $true
     }
 
-    # Take ownership of the staging directory and restrict it to Administrators and SYSTEM.
-    # This also neutralizes a directory pre-created by a non-elevated process.
-    $adminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
-    $systemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
-    $acl = New-Object System.Security.AccessControl.DirectorySecurity
-    $acl.SetOwner($adminSid)
-    $acl.SetAccessRuleProtection($true, $false)
-    foreach ($sid in @($adminSid, $systemSid)) {
-        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, 'ContainerInherit,ObjectInherit', 'None', 'Allow')))
-    }
-    Set-Acl -Path $stagingRoot -AclObject $acl
+    try {
+        # Resolve ProgramData through the known-folder API instead of the environment,
+        # which a non-elevated process can override via HKCU\Environment
+        $programDataPath = [Environment]::GetFolderPath([Environment+SpecialFolder]::CommonApplicationData)
+        $stagingRoot = Join-Path $programDataPath 'Win11Debloat'
 
-    # Copy the downloaded archive into the protected directory, then verify its integrity
-    $stagedArchive = Join-Path $stagingRoot 'win11debloat.zip'
-    Copy-Item -LiteralPath $archivePath -Destination $stagedArchive -Force
-
-    $actualHash = (Get-FileHash -LiteralPath $stagedArchive -Algorithm SHA256).Hash
-    if ($actualHash -ne $expectedHash) {
-        Remove-Item -LiteralPath $stagedArchive -Force
-        throw "Integrity check of the downloaded Win11Debloat archive failed. The file was modified after download, aborting for safety. (expected $expectedHash but got $actualHash)"
-    }
-
-    # One-time migration of configs, logs and backups from the old temp folder location
-    $legacyWorkPath = Join-Path $env:TEMP 'Win11Debloat'
-    foreach ($dirName in 'Config', 'Logs', 'Backups') {
-        $legacyDir = Join-Path $legacyWorkPath $dirName
-        $newDir = Join-Path $stagingRoot $dirName
-        if ((Test-Path $legacyDir) -and -not (Test-Path $newDir)) {
-            Copy-Item -Path $legacyDir -Destination $newDir -Recurse -Force
-        }
-    }
-
-    # Remove old script files if they exist, but keep configs, logs and backups
-    Write-Output "> Cleaning up old script files..."
-    Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups, win11debloat.zip | Remove-Item -Recurse -Force
-
-    $configDir = Join-Path $stagingRoot 'Config'
-    $backupDir = Join-Path $stagingRoot 'ConfigOld'
-
-    # Temporarily move existing config files to prevent them from being overwritten by the new script files
-    if (Test-Path $configDir) {
-        Write-Output ""
-        Write-Output "> Backing up existing config files..."
-
-        New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
-
-        $filesToKeep = @(
-            'LastUsedSettings.json'
-        )
-
-        Get-ChildItem -Path $configDir -Recurse | Where-Object { $_.Name -in $filesToKeep } | Move-Item -Destination $backupDir
-        Remove-Item $configDir -Recurse -Force
-    }
-
-    Write-Output ""
-    Write-Output "> Unpacking..."
-
-    Expand-Archive -LiteralPath $stagedArchive -DestinationPath $stagingRoot -Force
-    Remove-Item -LiteralPath $stagedArchive -Force
-
-    # Move the contents of the extracted release folder up into the staging root
-    $extractedRoot = Get-ChildItem -Path $stagingRoot -Directory -Filter '*Win11Debloat-*' | Select-Object -First 1
-    if ($null -eq $extractedRoot) {
-        throw "The downloaded archive did not contain the expected Win11Debloat folder."
-    }
-    Get-ChildItem -Path $extractedRoot.FullName -Force | Move-Item -Destination $stagingRoot -Force
-    Remove-Item -LiteralPath $extractedRoot.FullName -Recurse -Force
-
-    # Add existing config files back to Config folder
-    if (Test-Path $backupDir) {
-        if (-not (Test-Path $configDir)) {
-            New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+        # Refuse to follow a reparse point (junction/symlink) planted at the staging path.
+        # Delete the link entry itself without recursing into its target.
+        $existingStaging = Get-Item -LiteralPath $stagingRoot -Force -ErrorAction SilentlyContinue
+        if ($existingStaging -and ($existingStaging.Attributes -band [System.IO.FileAttributes]::ReparsePoint)) {
+            if ($existingStaging.Attributes -band [System.IO.FileAttributes]::Directory) {
+                [System.IO.Directory]::Delete($stagingRoot, $false)
+            }
+            else {
+                [System.IO.File]::Delete($stagingRoot)
+            }
+            $existingStaging = $null
         }
 
+        if (-not $existingStaging) {
+            New-Item -ItemType Directory -Path $stagingRoot | Out-Null
+        }
+
+        # Take ownership of the staging directory and restrict it to Administrators and SYSTEM.
+        # This also neutralizes a directory pre-created by a non-elevated process.
+        $adminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
+        $systemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
+        $acl = New-Object System.Security.AccessControl.DirectorySecurity
+        $acl.SetOwner($adminSid)
+        $acl.SetAccessRuleProtection($true, $false)
+        foreach ($sid in @($adminSid, $systemSid)) {
+            $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, 'ContainerInherit,ObjectInherit', 'None', 'Allow')))
+        }
+        Set-Acl -Path $stagingRoot -AclObject $acl
+
+        # Copy the downloaded archive into the protected directory, then verify its integrity
+        $stagedArchive = Join-Path $stagingRoot 'win11debloat.zip'
+        Copy-Item -LiteralPath $archivePath -Destination $stagedArchive -Force
+
+        $actualHash = (Get-FileHash -LiteralPath $stagedArchive -Algorithm SHA256).Hash
+        if ($actualHash -ne $expectedHash) {
+            Remove-Item -LiteralPath $stagedArchive -Force
+            throw "Integrity check of the downloaded Win11Debloat archive failed. The file was modified after download, aborting for safety. (expected $expectedHash but got $actualHash)"
+        }
+
+        # One-time migration of configs, logs and backups from the old temp folder location
+        $legacyWorkPath = Join-Path $env:TEMP 'Win11Debloat'
+        foreach ($dirName in 'Config', 'Logs', 'Backups') {
+            $legacyDir = Join-Path $legacyWorkPath $dirName
+            $newDir = Join-Path $stagingRoot $dirName
+            if ((Test-Path $legacyDir) -and -not (Test-Path $newDir)) {
+                Copy-Item -Path $legacyDir -Destination $newDir -Recurse -Force
+            }
+        }
+
+        # Remove old script files if they exist, but keep configs, logs and backups
+        Write-Output "> Cleaning up old script files..."
+        Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups, win11debloat.zip | Remove-Item -Recurse -Force
+
+        $configDir = Join-Path $stagingRoot 'Config'
+        $backupDir = Join-Path $stagingRoot 'ConfigOld'
+
+        # Temporarily move existing config files to prevent them from being overwritten by the new script files
+        if (Test-Path $configDir) {
+            Write-Output ""
+            Write-Output "> Backing up existing config files..."
+
+            New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+
+            $filesToKeep = @(
+                'LastUsedSettings.json'
+            )
+
+            Get-ChildItem -Path $configDir -Recurse | Where-Object { $_.Name -in $filesToKeep } | Move-Item -Destination $backupDir
+            Remove-Item $configDir -Recurse -Force
+        }
+
         Write-Output ""
-        Write-Output "> Restoring existing config files..."
+        Write-Output "> Unpacking..."
 
-        Get-ChildItem -Path $backupDir -Recurse | Move-Item -Destination $configDir -Force
-        Remove-Item $backupDir -Recurse -Force
+        # Restore the preserved config files in a finally block, so they are moved back
+        # into the Config folder even when unpacking fails midway
+        try {
+            Expand-Archive -LiteralPath $stagedArchive -DestinationPath $stagingRoot -Force
+            Remove-Item -LiteralPath $stagedArchive -Force
+
+            # Move the contents of the extracted release folder up into the staging root
+            $extractedRoot = Get-ChildItem -Path $stagingRoot -Directory -Filter '*Win11Debloat-*' | Select-Object -First 1
+            if ($null -eq $extractedRoot) {
+                throw "The downloaded archive did not contain the expected Win11Debloat folder."
+            }
+            Get-ChildItem -Path $extractedRoot.FullName -Force | Move-Item -Destination $stagingRoot -Force
+            Remove-Item -LiteralPath $extractedRoot.FullName -Recurse -Force
+        }
+        finally {
+            # Add existing config files back to Config folder
+            if (Test-Path $backupDir) {
+                if (-not (Test-Path $configDir)) {
+                    New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+                }
+
+                Write-Output ""
+                Write-Output "> Restoring existing config files..."
+
+                Get-ChildItem -Path $backupDir -Recurse | Move-Item -Destination $configDir -Force
+                Remove-Item $backupDir -Recurse -Force
+            }
+        }
+
+        Write-Output ""
+        Write-Output "> Launching Win11Debloat..."
+
+        # Run Win11Debloat script with the provided arguments (already elevated)
+        $debloatScriptPath = Join-Path $stagingRoot 'Win11Debloat.ps1'
+        $debloatProcess = Start-Process powershell.exe -WindowStyle $debloatWindowStyle -Wait -PassThru -ArgumentList "-executionpolicy bypass -File `"$debloatScriptPath`" $scriptArgs"
+
+        if ($null -ne $debloatProcess -and $debloatProcess.ExitCode -ne 0) {
+            throw "Win11Debloat.ps1 exited with code $($debloatProcess.ExitCode). Script files were kept in '$stagingRoot' for inspection, logs can be found in '$(Join-Path $stagingRoot 'Logs')'."
+        }
+
+        # Remove all remaining script files, except for configs, logs and backups
+        Write-Output ""
+        Write-Output "> Cleaning up..."
+        Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups | Remove-Item -Recurse -Force
     }
-
-    Write-Output ""
-    Write-Output "> Launching Win11Debloat..."
-
-    # Run Win11Debloat script with the provided arguments (already elevated)
-    $debloatScriptPath = Join-Path $stagingRoot 'Win11Debloat.ps1'
-    Start-Process powershell.exe -WindowStyle $debloatWindowStyle -Wait -ArgumentList "-executionpolicy bypass -File `"$debloatScriptPath`" $scriptArgs"
-
-    # Remove all remaining script files, except for configs, logs and backups
-    Write-Output ""
-    Write-Output "> Cleaning up..."
-    Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups | Remove-Item -Recurse -Force
+    finally {
+        if ($mutexAcquired) {
+            $bootstrapMutex.ReleaseMutex()
+        }
+        $bootstrapMutex.Dispose()
+    }
 }
 catch {
     Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -105,7 +105,7 @@ param (
     [switch]$HideDriveLetters
 )
 
-# Show error if current powershell environment does not have LanguageMode set to FullLanguage 
+# Show error if current powershell environment does not have LanguageMode set to FullLanguage
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
    Write-Host "Error: Win11Debloat is unable to run on your system. PowerShell execution is restricted by security policies" -ForegroundColor Red
    Write-Output ""
@@ -119,9 +119,7 @@ Write-Output "------------------------------------------------------------------
 Write-Output " Win11Debloat Script"
 Write-Output "-------------------------------------------------------------------------------------------"
 
-$tempRootPath = $env:TEMP
-$tempWorkPath = Join-Path $tempRootPath 'Win11Debloat'
-$tempArchivePath = Join-Path $tempRootPath 'win11debloat.zip'
+$tempArchivePath = Join-Path $env:TEMP 'win11debloat.zip'
 
 # Download Win11Debloat from GitHub as a zip archive.
 try {
@@ -142,63 +140,16 @@ catch {
     Exit
 }
 
-# Remove old script folder if it exists, but keep configs, logs and backups
-if (Test-Path $tempWorkPath) {
-    Write-Output ""
-    Write-Output "> Cleaning up old script files..."
-
-    Get-ChildItem -Path $tempWorkPath -Exclude Config,Logs,Backups | Remove-Item -Recurse -Force
-}
-
-$configDir = Join-Path $tempWorkPath 'Config'
-$backupDir = Join-Path $tempWorkPath 'ConfigOld'
-
-# Temporarily move existing config files if they exist to prevent them from being overwritten by the new script files, will be moved back after the new script is unpacked
-if (Test-Path "$configDir") {
-    Write-Output ""
-    Write-Output "> Backing up existing config files..."
-
-    New-Item -ItemType Directory -Path "$backupDir" -Force | Out-Null
-
-    $filesToKeep = @(
-        'LastUsedSettings.json'
-    )
-
-    Get-ChildItem -Path "$configDir" -Recurse | Where-Object { $_.Name -in $filesToKeep } | Move-Item -Destination "$backupDir"
-
-    Remove-Item "$configDir" -Recurse -Force
-}
-
-Write-Output ""
-Write-Output "> Unpacking..."
-
-# Unzip archive to Win11Debloat folder
-Expand-Archive $tempArchivePath $tempWorkPath
-
-# Remove archive
-Remove-Item $tempArchivePath
-
-# Move files
-Get-ChildItem -Path (Join-Path $tempWorkPath '*Win11Debloat-*') -Recurse | Move-Item -Destination $tempWorkPath
-
-# Add existing config files back to Config folder
-if (Test-Path "$backupDir") {
-    if (-not (Test-Path "$configDir")) {
-        New-Item -ItemType Directory -Path "$configDir" -Force | Out-Null
-    }
-
-    Write-Output ""
-    Write-Output "> Restoring existing config files..."
-
-    Get-ChildItem -Path "$backupDir" -Recurse | Move-Item -Destination "$configDir"
-    Remove-Item "$backupDir" -Recurse -Force
-}
+# Record the archive hash immediately after download. The hash is passed to the elevated
+# process, which re-verifies the archive after copying it into a protected directory. This
+# prevents a non-elevated process from swapping the files between download and elevated execution.
+$archiveHash = (Get-FileHash -LiteralPath $tempArchivePath -Algorithm SHA256).Hash
 
 # Make list of arguments to pass on to the script (exclude the -Dev switch, which only affects this launcher)
 $arguments = $($PSBoundParameters.GetEnumerator() | Where-Object { $_.Key -ne 'Dev' } | ForEach-Object {
     if ($_.Value -eq $true) {
         "-$($_.Key)"
-    } 
+    }
     else {
          "-$($_.Key) ""$($_.Value)"""
     }
@@ -221,22 +172,147 @@ if ($PSVersionTable.PSVersion.Major -ge 7) {
     $env:PSModulePath = $NewPSModulePath -join ';'
 }
 
-# Run Win11Debloat script with the provided arguments
-$debloatScriptPath = Join-Path $tempWorkPath 'Win11Debloat.ps1'
-$debloatProcess = Start-Process powershell.exe -WindowStyle $windowStyle -PassThru -ArgumentList "-executionpolicy bypass -File `"$debloatScriptPath`" $arguments" -Verb RunAs
-
-# Wait for the process to finish before continuing
-if ($null -ne $debloatProcess) {
-    $debloatProcess.WaitForExit()
+# Escapes a value for embedding inside a single-quoted PowerShell string literal
+function Format-EmbeddedLiteral([string]$Value) {
+    return "'" + ($Value -replace "'", "''") + "'"
 }
 
-# Remove all remaining script files, except for configs, logs and backups
-if (Test-Path $tempWorkPath) {
+# The bootstrap below runs elevated. It stages, verifies and executes the script inside a
+# directory that only Administrators and SYSTEM can write to, so that unpacked script files
+# cannot be tampered with by non-elevated processes before or during elevated execution.
+$bootstrapTemplate = @'
+$ErrorActionPreference = 'Stop'
+$archivePath = __ARCHIVE__
+$expectedHash = __HASH__
+$scriptArgs = __ARGS__
+$debloatWindowStyle = __WINDOWSTYLE__
+
+try {
+    $stagingRoot = Join-Path $env:ProgramData 'Win11Debloat'
+
+    if (-not (Test-Path -LiteralPath $stagingRoot)) {
+        New-Item -ItemType Directory -Path $stagingRoot | Out-Null
+    }
+
+    # Take ownership of the staging directory and restrict it to Administrators and SYSTEM.
+    # This also neutralizes a directory pre-created by a non-elevated process.
+    $adminSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::BuiltinAdministratorsSid, $null)
+    $systemSid = New-Object System.Security.Principal.SecurityIdentifier([System.Security.Principal.WellKnownSidType]::LocalSystemSid, $null)
+    $acl = New-Object System.Security.AccessControl.DirectorySecurity
+    $acl.SetOwner($adminSid)
+    $acl.SetAccessRuleProtection($true, $false)
+    foreach ($sid in @($adminSid, $systemSid)) {
+        $acl.AddAccessRule((New-Object System.Security.AccessControl.FileSystemAccessRule($sid, [System.Security.AccessControl.FileSystemRights]::FullControl, 'ContainerInherit,ObjectInherit', 'None', 'Allow')))
+    }
+    Set-Acl -Path $stagingRoot -AclObject $acl
+
+    # Copy the downloaded archive into the protected directory, then verify its integrity
+    $stagedArchive = Join-Path $stagingRoot 'win11debloat.zip'
+    Copy-Item -LiteralPath $archivePath -Destination $stagedArchive -Force
+
+    $actualHash = (Get-FileHash -LiteralPath $stagedArchive -Algorithm SHA256).Hash
+    if ($actualHash -ne $expectedHash) {
+        Remove-Item -LiteralPath $stagedArchive -Force
+        throw "Integrity check of the downloaded Win11Debloat archive failed. The file was modified after download, aborting for safety. (expected $expectedHash but got $actualHash)"
+    }
+
+    # One-time migration of configs, logs and backups from the old temp folder location
+    $legacyWorkPath = Join-Path $env:TEMP 'Win11Debloat'
+    foreach ($dirName in 'Config', 'Logs', 'Backups') {
+        $legacyDir = Join-Path $legacyWorkPath $dirName
+        $newDir = Join-Path $stagingRoot $dirName
+        if ((Test-Path $legacyDir) -and -not (Test-Path $newDir)) {
+            Copy-Item -Path $legacyDir -Destination $newDir -Recurse -Force
+        }
+    }
+
+    # Remove old script files if they exist, but keep configs, logs and backups
+    Write-Output "> Cleaning up old script files..."
+    Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups, win11debloat.zip | Remove-Item -Recurse -Force
+
+    $configDir = Join-Path $stagingRoot 'Config'
+    $backupDir = Join-Path $stagingRoot 'ConfigOld'
+
+    # Temporarily move existing config files to prevent them from being overwritten by the new script files
+    if (Test-Path $configDir) {
+        Write-Output ""
+        Write-Output "> Backing up existing config files..."
+
+        New-Item -ItemType Directory -Path $backupDir -Force | Out-Null
+
+        $filesToKeep = @(
+            'LastUsedSettings.json'
+        )
+
+        Get-ChildItem -Path $configDir -Recurse | Where-Object { $_.Name -in $filesToKeep } | Move-Item -Destination $backupDir
+        Remove-Item $configDir -Recurse -Force
+    }
+
+    Write-Output ""
+    Write-Output "> Unpacking..."
+
+    Expand-Archive -LiteralPath $stagedArchive -DestinationPath $stagingRoot -Force
+    Remove-Item -LiteralPath $stagedArchive -Force
+
+    # Move the contents of the extracted release folder up into the staging root
+    $extractedRoot = Get-ChildItem -Path $stagingRoot -Directory -Filter '*Win11Debloat-*' | Select-Object -First 1
+    if ($null -eq $extractedRoot) {
+        throw "The downloaded archive did not contain the expected Win11Debloat folder."
+    }
+    Get-ChildItem -Path $extractedRoot.FullName -Force | Move-Item -Destination $stagingRoot -Force
+    Remove-Item -LiteralPath $extractedRoot.FullName -Recurse -Force
+
+    # Add existing config files back to Config folder
+    if (Test-Path $backupDir) {
+        if (-not (Test-Path $configDir)) {
+            New-Item -ItemType Directory -Path $configDir -Force | Out-Null
+        }
+
+        Write-Output ""
+        Write-Output "> Restoring existing config files..."
+
+        Get-ChildItem -Path $backupDir -Recurse | Move-Item -Destination $configDir -Force
+        Remove-Item $backupDir -Recurse -Force
+    }
+
+    Write-Output ""
+    Write-Output "> Launching Win11Debloat..."
+
+    # Run Win11Debloat script with the provided arguments (already elevated)
+    $debloatScriptPath = Join-Path $stagingRoot 'Win11Debloat.ps1'
+    Start-Process powershell.exe -WindowStyle $debloatWindowStyle -Wait -ArgumentList "-executionpolicy bypass -File `"$debloatScriptPath`" $scriptArgs"
+
+    # Remove all remaining script files, except for configs, logs and backups
     Write-Output ""
     Write-Output "> Cleaning up..."
-
-    # Cleanup, remove Win11Debloat directory
-    Get-ChildItem -Path $tempWorkPath -Exclude Config,Logs,Backups | Remove-Item -Recurse -Force
+    Get-ChildItem -Path $stagingRoot -Exclude Config, Logs, Backups | Remove-Item -Recurse -Force
 }
+catch {
+    Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
+    Write-Output ""
+    Write-Output "Press enter to exit..."
+    Read-Host | Out-Null
+    Exit 1
+}
+'@
+
+$bootstrap = $bootstrapTemplate.
+    Replace('__ARCHIVE__', (Format-EmbeddedLiteral $tempArchivePath)).
+    Replace('__HASH__', (Format-EmbeddedLiteral $archiveHash)).
+    Replace('__ARGS__', (Format-EmbeddedLiteral ($arguments -join ' '))).
+    Replace('__WINDOWSTYLE__', (Format-EmbeddedLiteral $windowStyle))
+
+$encodedBootstrap = [Convert]::ToBase64String([System.Text.Encoding]::Unicode.GetBytes($bootstrap))
+
+# Elevate and run the bootstrap, which verifies, unpacks and launches Win11Debloat
+$elevatedProcess = Start-Process powershell.exe -PassThru -Verb RunAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -EncodedCommand $encodedBootstrap"
+
+# Wait for the process to finish before continuing
+if ($null -ne $elevatedProcess) {
+    $elevatedProcess.WaitForExit()
+}
+
+# Remove the downloaded archive from the user temp folder
+Remove-Item -LiteralPath $tempArchivePath -Force -ErrorAction SilentlyContinue
 
 Write-Output ""


### PR DESCRIPTION
## Summary

Two security fixes found during a review of the codebase:

### 1. `Scripts/Get.ps1` — unpacked script files were executed elevated from a user-writable directory

The launcher downloaded and unpacked the archive into `%TEMP%\Win11Debloat` and then ran `Win11Debloat.ps1` elevated from there. Between unpacking and elevation (and during the elevated run), any non-elevated process running as the same user could swap the unpacked `.ps1` files - which `Win11Debloat.ps1` dot-sources - and get its own code executed with administrator rights behind the UAC prompt the user intended for Win11Debloat.

The launcher now:
- records the SHA-256 of the archive immediately after download
- elevates a bootstrap that creates (or takes over) `%ProgramData%\Win11Debloat`, restricting it to **Administrators + SYSTEM** with inheritance disabled - this also neutralizes a pre-created attacker directory
- copies the archive into the protected directory and **re-verifies the hash there**, aborting on mismatch
- unpacks, restores `LastUsedSettings.json`, runs `Win11Debloat.ps1` and cleans up entirely inside the protected directory
- migrates existing `Config`, `Logs` and `Backups` from the old `%TEMP%\Win11Debloat` location on first run

Behavior change: the working directory moves from `%TEMP%\Win11Debloat` to `%ProgramData%\Win11Debloat`, which is inherent to the fix - the staging area must be somewhere a non-admin process cannot write.

### 2. `Scripts/AppRemoval/Invoke-ForceRemoveEdge.ps1` — could delete the real EdgeHTML package on Windows 10

`ForceRemoveEdge` unconditionally created a stub at `%SystemRoot%\SystemApps\Microsoft.MicrosoftEdge_8wekyb3d8bbwe` and later recursively deleted that path. On Windows 10 this folder is the genuine legacy Edge (EdgeHTML) system package: `New-Item` failed non-terminally, execution continued, and the real system component was deleted. `ForceRemoveEdge` has no `MinVersion` gate in `Features.json`, so nothing prevented this on Windows 10.

Fixed by:
- locating the uninstaller **before** mutating anything, bailing out early when missing
- only creating the stub when the folder does not already exist, and only deleting it if this run created it
- cleaning up the stub in a `finally` block so no fake `MicrosoftEdge.exe` is left in `SystemApps` when the uninstall fails (previously it was left behind permanently when the uninstall registry key was missing)
- invoking the `UninstallString` directly via `Start-Process` instead of interpolating the raw registry value into a `cmd.exe /c` command line

## Test plan

- Full Pester suite: **450 passed, 0 failed** (`Scripts/Run-Tests.ps1`)
- Both files pass PowerShell parser validation; the embedded elevated bootstrap template was rendered and parser-validated as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Hardened `Scripts/Get.ps1` against launcher TOCTOU attacks.
- Downloaded, verified, extracted, and executed archives in the elevated `%ProgramData%\Win11Debloat` staging directory.
- Secured staging with ACL checks, reparse-point protection, unique archive names, and concurrent-run serialization.
- Migrated configuration, logs, and backups from `%TEMP%\Win11Debloat`.
- Preserved configuration after failed unpacking and retained staged files when the launched script fails.
- Propagated elevated bootstrap failures to the launcher.
- Escaped literal bootstrap inputs to prevent recursive token-replacement corruption.
- Hardened Edge removal by validating the uninstaller, invoking it directly, and cleaning up conditional stubs with `finally`.
- Added comment-based help for `Format-EmbeddedLiteral`.
- All 450 Pester tests pass.
- PowerShell parser validation passes for the modified files and elevated bootstrap template.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->