### PR TITLE
Improve error handling in Set-StoreSearchSuggestionsDisabled

### DIFF
--- a/Scripts/Features/Set-StoreSearchSuggestions.ps1
+++ b/Scripts/Features/Set-StoreSearchSuggestions.ps1
@@ -73,11 +73,17 @@ function Set-StoreSearchSuggestionsDisabled {
         New-Item -Path $StoreAppsDatabase -ItemType File -Force | Out-Null
     }
     
-    $AccountSid = [System.Security.Principal.SecurityIdentifier]::new('S-1-1-0') # 'EVERYONE' group
-    $Acl = Get-Acl -Path $StoreAppsDatabase
-    $Ace = [System.Security.AccessControl.FileSystemAccessRule]::new($AccountSid, 'FullControl', 'Deny')
-    $Acl.SetAccessRule($Ace) | Out-Null
-    Set-Acl -Path $StoreAppsDatabase -AclObject $Acl | Out-Null
+    try {
+        $AccountSid = [System.Security.Principal.SecurityIdentifier]::new('S-1-1-0') # 'EVERYONE' group
+        $Acl = Get-Acl -Path $StoreAppsDatabase -ErrorAction Stop
+        $Ace = [System.Security.AccessControl.FileSystemAccessRule]::new($AccountSid, 'FullControl', 'Deny')
+        $Acl.SetAccessRule($Ace) | Out-Null
+        Set-Acl -Path $StoreAppsDatabase -AclObject $Acl -ErrorAction Stop | Out-Null
+    }
+    catch {
+        Write-Warning "Failed to restrict ACL for store database '$StoreAppsDatabase': $($_.Exception.Message)"
+        return
+    }
 
     Write-Host "Disabled Microsoft Store search suggestions for user $userName"
 }

--- a/Tests/Set-StoreSearchSuggestions.Tests.ps1
+++ b/Tests/Set-StoreSearchSuggestions.Tests.ps1
@@ -126,17 +126,32 @@ Describe 'Set-StoreSearchSuggestionsDisabled' {
         $acl.AddedRules | Should -HaveCount 1
     }
 
-    It 'surfaces ACL failures instead of reporting the database as disabled' {
+    It 'warns and does not report success when reading the ACL fails' {
         $script:Params = @{}
         Mock Test-Path { $true }
         Mock Get-Acl { throw 'access denied' }
         Mock Set-Acl { throw 'ACL must not be written after a read failure.' }
+        Mock Write-Warning {}
 
-        {
-            Set-StoreSearchSuggestionsDisabled -StoreAppsDatabase 'C:\Users\Alice\AppData\Local\Packages\store.db'
-        } | Should -Throw '*access denied*'
+        Set-StoreSearchSuggestionsDisabled -StoreAppsDatabase 'C:\Users\Alice\AppData\Local\Packages\store.db'
 
+        Should -Invoke Write-Warning -Times 1 -Exactly
+        Should -Invoke Write-Host -Times 0 -Exactly -ParameterFilter { $Object -like 'Disabled Microsoft Store search suggestions*' }
         Should -Invoke Set-Acl -Times 0 -Exactly
+    }
+
+    It 'warns and does not report success when writing the ACL fails' {
+        $script:Params = @{}
+        $acl = New-TestStoreDatabaseAcl
+        Mock Test-Path { $true }
+        Mock Get-Acl { $acl }
+        Mock Set-Acl { throw 'access denied' }
+        Mock Write-Warning {}
+
+        Set-StoreSearchSuggestionsDisabled -StoreAppsDatabase 'C:\Users\Alice\AppData\Local\Packages\store.db'
+
+        Should -Invoke Write-Warning -Times 1 -Exactly
+        Should -Invoke Write-Host -Times 0 -Exactly -ParameterFilter { $Object -like 'Disabled Microsoft Store search suggestions*' }
     }
 }
 


### PR DESCRIPTION
Addresses #738, ensure that issues with execution of Get-Acl don't fully block execution. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary by CodeRabbit

- Added error handling for ACL retrieval and application in `Set-StoreSearchSuggestionsDisabled`.
- Emit a warning and stop execution when an ACL operation fails.
- Prevent the success message after an ACL failure.
- Added tests for ACL read and write failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->