### PR TITLE
Add option to ignore keyboard layouts from other devices on the network

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -815,6 +815,20 @@
       "MaxVersion": null
     },
     {
+      "FeatureId": "DisableRemoteKeyboardLayout",
+      "Label": "Disable adding keyboard layouts from other devices on the network",
+      "ToolTip": "Windows can automatically add keyboard layouts that it finds on other devices on networks you connect to. These layouts often do not appear in Settings and are hard to remove. This setting prevents Windows from adding those remote layouts. A reboot is required.",
+      "Category": "System",
+      "RegistryKey": "Disable_Remote_Keyboard_Layout.reg",
+      "ApplyText": "Disabling remote keyboard layout auto-add",
+      "UndoLabel": "Allow adding keyboard layouts from other devices on the network",
+      "ApplyUndoText": "Allowing remote keyboard layout auto-add",
+      "RegistryUndoKey": "Enable_Remote_Keyboard_Layout.reg",
+      "RequiresReboot": true,
+      "MinVersion": null,
+      "MaxVersion": null
+    },
+    {
       "FeatureId": "DisableWindowSnapping",
       "Label": "Disable window snapping",
       "ToolTip": "This will turn off the ability to snap windows to the sides or corners of the screen.",

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Below is an overview of the key features and functionality offered by Win11Deblo
 - Restore the old Windows 10 style context menu.
 - Turn off Enhance Pointer Precision (mouse acceleration).
 - Disable the Sticky Keys keyboard shortcut.
+- Prevent Windows from adding keyboard layouts found on other devices on the network.
 - Disable Storage Sense automatic disk cleanup.
 - Disable fast start-up to ensure a full shutdown.
 - Disable BitLocker automatic device encryption.

--- a/Regfiles/Disable_Remote_Keyboard_Layout.reg
+++ b/Regfiles/Disable_Remote_Keyboard_Layout.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Keyboard Layout]
+"IgnoreRemoteKeyboardLayout"=dword:00000001

--- a/Regfiles/Sysprep/Disable_Remote_Keyboard_Layout.reg
+++ b/Regfiles/Sysprep/Disable_Remote_Keyboard_Layout.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Keyboard Layout]
+"IgnoreRemoteKeyboardLayout"=dword:00000001

--- a/Regfiles/Undo/Enable_Remote_Keyboard_Layout.reg
+++ b/Regfiles/Undo/Enable_Remote_Keyboard_Layout.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\Keyboard Layout]
+"IgnoreRemoteKeyboardLayout"=-

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -82,6 +82,7 @@ param (
     [switch]$DisableDragTray,
     [switch]$DisableMouseAcceleration,
     [switch]$DisableStickyKeys,
+    [switch]$DisableRemoteKeyboardLayout,
     [switch]$DisableWindowSnapping,
     [switch]$DisableSnapAssist,
     [switch]$DisableSnapLayouts,

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -80,6 +80,7 @@ param (
     [switch]$DisableDragTray,
     [switch]$DisableMouseAcceleration,
     [switch]$DisableStickyKeys,
+    [switch]$DisableRemoteKeyboardLayout,
     [switch]$DisableWindowSnapping,
     [switch]$DisableSnapAssist,
     [switch]$DisableSnapLayouts,


### PR DESCRIPTION
## Summary
- Adds `-DisableRemoteKeyboardLayout` so Windows ignores keyboard layouts advertised by other devices on the network.
- Sets `HKLM\SYSTEM\CurrentControlSet\Control\Keyboard Layout\IgnoreRemoteKeyboardLayout` to `1`, with matching Sysprep and undo `.reg` files.
- Not added to the default preset.

Fixes #677

## Test plan
- [ ] Apply `-DisableRemoteKeyboardLayout` and confirm `IgnoreRemoteKeyboardLayout` is `1` under `HKLM\SYSTEM\CurrentControlSet\Control\Keyboard Layout`
- [ ] Confirm the Sysprep `.reg` uses the same HKLM path
- [ ] Undo restores the previous state (value removed)
- [ ] Confirm a reboot is reported as required


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary by CodeRabbit

- Added the `-DisableRemoteKeyboardLayout` option.
- Set `IgnoreRemoteKeyboardLayout` to `1` in the Windows registry.
- Added matching Sysprep and undo registry files.
- Marked the option as requiring a reboot.
- Excluded the option from the default preset.
- Documented the feature in `README.md`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->