### PR TITLE
Surface the underlying GitHub error when the launcher download fails

### DIFF
--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -105,6 +105,23 @@ param (
     [switch]$HideDriveLetters
 )
 
+<#
+    .SYNOPSIS
+        Formats the user-facing error shown when the launcher cannot download Win11Debloat.
+
+    .DESCRIPTION
+        Always starts with the generic GitHub download failure message. Appends the
+        exception message when it is present, then appends ErrorDetails.Message when
+        it is present and different from the exception text (for example a GitHub
+        API rate-limit body).
+
+    .PARAMETER ErrorRecord
+        The caught error from the GitHub download attempt.
+
+    .OUTPUTS
+        System.String
+        A newline-separated message suitable for Write-Host.
+#>
 function Get-GitHubDownloadFailureMessage {
     param(
         [Parameter(Mandatory)]

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -105,6 +105,34 @@ param (
     [switch]$HideDriveLetters
 )
 
+function Get-GitHubDownloadFailureMessage {
+    param(
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorRecord]$ErrorRecord
+    )
+
+    $lines = New-Object System.Collections.Generic.List[string]
+    [void]$lines.Add('Error: Unable to fetch required files from GitHub. Please check your internet connection and try again.')
+
+    $exceptionMessage = $null
+    if ($ErrorRecord.Exception) {
+        $exceptionMessage = [string]$ErrorRecord.Exception.Message
+    }
+    if (-not [string]::IsNullOrWhiteSpace($exceptionMessage)) {
+        [void]$lines.Add($exceptionMessage)
+    }
+
+    $details = $null
+    if ($ErrorRecord.ErrorDetails) {
+        $details = [string]$ErrorRecord.ErrorDetails.Message
+    }
+    if (-not [string]::IsNullOrWhiteSpace($details) -and $details -ne $exceptionMessage) {
+        [void]$lines.Add($details)
+    }
+
+    return ($lines -join [Environment]::NewLine)
+}
+
 # Check if current PowerShell environment is limited by security policies
 if ($ExecutionContext.SessionState.LanguageMode -ne "FullLanguage") {
     Write-Error "Win11Debloat is unable to run on your system, PowerShell execution is restricted by security policies"
@@ -134,7 +162,7 @@ try {
     Invoke-RestMethod $sourceUri -OutFile $tempArchivePath
 }
 catch {
-    Write-Host "Error: Unable to fetch required files from GitHub. Please check your internet connection and try again." -ForegroundColor Red
+    Write-Host (Get-GitHubDownloadFailureMessage -ErrorRecord $_) -ForegroundColor Red
     Write-Output ""
     Write-Output "Press enter to exit..."
     Read-Host | Out-Null

--- a/Tests/GetLauncher.Tests.ps1
+++ b/Tests/GetLauncher.Tests.ps1
@@ -1,0 +1,49 @@
+BeforeAll {
+    $getScriptPath = Join-Path $PSScriptRoot '..\Scripts\Get.ps1'
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($getScriptPath, [ref]$tokens, [ref]$parseErrors)
+    $parseErrors | Should -BeNullOrEmpty
+
+    $functionAst = $ast.FindAll({
+            param($node)
+            $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+            $node.Name -eq 'Get-GitHubDownloadFailureMessage'
+        }, $true) | Select-Object -First 1
+
+    $functionAst | Should -Not -BeNullOrEmpty
+    . ([scriptblock]::Create($functionAst.Extent.Text))
+}
+
+Describe 'Get-GitHubDownloadFailureMessage' {
+    It 'keeps the original user-facing error and appends the exception message' {
+        $errorRecord = $null
+        try {
+            throw 'Response status code does not indicate success: 403 (Forbidden).'
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        $message = Get-GitHubDownloadFailureMessage -ErrorRecord $errorRecord
+
+        $message | Should -Match 'Unable to fetch required files from GitHub'
+        $message | Should -Match '403 \(Forbidden\)'
+    }
+
+    It 'appends GitHub ErrorDetails when they differ from the exception message' {
+        $errorRecord = $null
+        try {
+            throw 'The remote server returned an error: (403) Forbidden.'
+        }
+        catch {
+            $errorRecord = $_
+        }
+
+        $errorRecord.ErrorDetails = [System.Management.Automation.ErrorDetails]::new('API rate limit exceeded for 1.2.3.4')
+        $message = Get-GitHubDownloadFailureMessage -ErrorRecord $errorRecord
+
+        $message | Should -Match 'The remote server returned an error'
+        $message | Should -Match 'API rate limit exceeded'
+    }
+}


### PR DESCRIPTION
## Summary
- When `Scripts/Get.ps1` cannot download Win11Debloat from GitHub, keep the original connection error and append the underlying exception.
- Also append GitHub `ErrorDetails` when they add information, such as API rate-limit messages.
- Tests parse `Get.ps1` and evaluate only the new helper, so the launcher is never executed.

Closes https://github.com/Raphire/Win11Debloat/discussions/743

## Test plan
- [ ] `Tests/GetLauncher.Tests.ps1` covers exception text and distinct `ErrorDetails`
- [ ] Confirm a simulated 403/rate-limit failure prints both the original message and the GitHub reason


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Added `Get-GitHubDownloadFailureMessage` to preserve the original connection error and append the underlying exception.
- Included distinct GitHub `ErrorDetails`, including API rate-limit messages.
- Updated the download failure handler to use the new helper.
- Added isolated Pester tests that parse `Get.ps1` and validate the helper behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->