### PR TITLE
Add an option to disable Windows 11 delayed startup-app launch

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1037,6 +1037,19 @@
       "MaxVersion": null
     },
     {
+      "FeatureId": "DisableStartupDelay",
+      "Label": "Disable delayed launch of startup apps",
+      "ToolTip": "Windows 11 can delay launching startup apps until the system is considered idle. This removes that delay so startup apps launch immediately. On slower hardware this can make the desktop feel busier at logon rather than faster.",
+      "Category": "System",
+      "RegistryKey": "Disable_Startup_Delay.reg",
+      "ApplyText": "Disabling delayed launch of startup apps",
+      "UndoLabel": "Enable delayed launch of startup apps",
+      "ApplyUndoText": "Enabling delayed launch of startup apps",
+      "RegistryUndoKey": "Enable_Startup_Delay.reg",
+      "MinVersion": 22000,
+      "MaxVersion": null
+    },
+    {
       "FeatureId": "DisableBitlockerAutoEncryption",
       "Label": "Disable BitLocker automatic device encryption",
       "ToolTip": "For devices that support it, Windows 11 automatically enables BitLocker device encryption. Disabling this will turn off automatic encryption of the device, but you can still manually enable BitLocker encryption if desired. Drives that are already encrypted with BitLocker will remain encrypted when this setting is applied.",

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Below is an overview of the key features and functionality offered by Win11Deblo
 - Disable the Sticky Keys keyboard shortcut.
 - Disable Storage Sense automatic disk cleanup.
 - Disable fast start-up to ensure a full shutdown.
+- Disable the delay that waits for the system to be idle before launching startup apps.
 - Disable BitLocker automatic device encryption.
 - Disable network connectivity during Modern Standby to reduce battery drain.
 

--- a/Regfiles/Disable_Startup_Delay.reg
+++ b/Regfiles/Disable_Startup_Delay.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+"StartupDelayInMSec"=dword:00000000
+"WaitForIdleState"=dword:00000000

--- a/Regfiles/Sysprep/Disable_Startup_Delay.reg
+++ b/Regfiles/Sysprep/Disable_Startup_Delay.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[hkey_users\default\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+"StartupDelayInMSec"=dword:00000000
+"WaitForIdleState"=dword:00000000

--- a/Regfiles/Sysprep/Undo/Enable_Startup_Delay.reg
+++ b/Regfiles/Sysprep/Undo/Enable_Startup_Delay.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[hkey_users\default\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+"StartupDelayInMSec"=-
+"WaitForIdleState"=-

--- a/Regfiles/Undo/Enable_Startup_Delay.reg
+++ b/Regfiles/Undo/Enable_Startup_Delay.reg
@@ -1,0 +1,5 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize]
+"StartupDelayInMSec"=-
+"WaitForIdleState"=-

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -28,6 +28,7 @@ param (
     [switch]$DisableTelemetry,
     [switch]$DisableSearchHistory,
     [switch]$DisableFastStartup,
+    [switch]$DisableStartupDelay,
     [switch]$DisableBitlockerAutoEncryption,
     [switch]$DisableModernStandbyNetworking,
     [switch]$DisableNotifications,

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -26,6 +26,7 @@ param (
     [switch]$DisableTelemetry,
     [switch]$DisableSearchHistory,
     [switch]$DisableFastStartup,
+    [switch]$DisableStartupDelay,
     [switch]$DisableBitlockerAutoEncryption,
     [switch]$DisableModernStandbyNetworking,
     [switch]$DisableStorageSense,


### PR DESCRIPTION
## Summary
- Adds `-DisableStartupDelay` to stop Windows 11 from delaying startup-app launch.
- Sets `HKCU\Software\Microsoft\Windows\CurrentVersion\Explorer\Serialize` `StartupDelayInMSec` and `WaitForIdleState` to `0`.
- Windows 11+ only (`MinVersion` 22000). Tooltip notes this can slow logon on slower PCs. Not added to the default preset.

Fixes #482

## Test plan
- [ ] Apply the option and confirm both DWORD values are `0`
- [ ] Undo restores the previous values
- [ ] Sysprep `.reg` uses `hkey_users\default`
- [ ] Feature is hidden/unavailable on Windows 10 builds below 22000


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Added the `-DisableStartupDelay` option for Windows 11 and later.
- Set `StartupDelayInMSec` and `WaitForIdleState` to `0` under the Explorer `Serialize` registry key.
- Added registry files for applying, undoing, and Sysprep configuration.
- Added feature metadata, launcher parameters, README documentation, and a startup-delay warning.
- Excluded the option from the default preset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->