### PR TITLE
Add an option to disable File Explorer folder auto-discovery

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1275,6 +1275,20 @@
       "MaxVersion": null
     },
     {
+      "FeatureId": "DisableExplorerAutoDiscovery",
+      "Label": "Disable File Explorer folder auto-discovery",
+      "ToolTip": "File Explorer periodically scans folders to guess a view type such as pictures or documents. That scan can slow Explorer in folders with thousands of files. This sets every folder's type to NotSpecified so you choose the view yourself. Explorer is restarted after applying changes unless you skip that step.",
+      "Category": "File Explorer",
+      "Priority": 14,
+      "RegistryKey": "Disable_Explorer_Auto_Discovery.reg",
+      "ApplyText": "Disabling File Explorer folder auto-discovery",
+      "UndoLabel": "Enable File Explorer folder auto-discovery",
+      "ApplyUndoText": "Enabling File Explorer folder auto-discovery",
+      "RegistryUndoKey": "Enable_Explorer_Auto_Discovery.reg",
+      "MinVersion": null,
+      "MaxVersion": null
+    },
+    {
       "FeatureId": "HideDupliDrive",
       "Label": "Hide duplicate removable drive entries",
       "ToolTip": "By default, Windows shows removable drives both under 'This PC' and in the navigation pane with its own entry. Enable this setting to only show removable drives under 'This PC'.",

--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1277,7 +1277,7 @@
     {
       "FeatureId": "DisableExplorerAutoDiscovery",
       "Label": "Disable File Explorer folder auto-discovery",
-      "ToolTip": "File Explorer periodically scans folders to guess a view type such as pictures or documents. That scan can slow Explorer in folders with thousands of files. This sets every folder's type to NotSpecified so you choose the view yourself. Explorer is restarted after applying changes unless you skip that step.",
+      "ToolTip": "File Explorer periodically scans folders to guess a view type such as pictures or documents. That scan can slow Explorer in folders with thousands of files. This sets every folder's type to NotSpecified so you choose the view yourself. Explorer is restarted after applying changes in normal runs unless you skip that step; User and Sysprep modes take effect when the target profile starts Explorer.",
       "Category": "File Explorer",
       "Priority": 14,
       "RegistryKey": "Disable_Explorer_Auto_Discovery.reg",

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ Below is an overview of the key features and functionality offered by Win11Deblo
 - Change the default location that File Explorer opens to.
 - Show file extensions for known file types.
 - Show hidden files, folders and drives.
+- Disable File Explorer folder auto-discovery that repeatedly scans directories to pick a view type.
 - Hide the Home, Gallery or OneDrive section from the File Explorer navigation pane.
 - Hide duplicate removable drive entries from the File Explorer navigation pane, so only the entry under 'This PC' remains.
 - Add all common folders (Desktop, Downloads, etc.) back to 'This PC' in File Explorer.

--- a/Regfiles/Disable_Explorer_Auto_Discovery.reg
+++ b/Regfiles/Disable_Explorer_Auto_Discovery.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell]
+"FolderType"="NotSpecified"

--- a/Regfiles/Sysprep/Disable_Explorer_Auto_Discovery.reg
+++ b/Regfiles/Sysprep/Disable_Explorer_Auto_Discovery.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[hkey_users\default\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell]
+"FolderType"="NotSpecified"

--- a/Regfiles/Undo/Enable_Explorer_Auto_Discovery.reg
+++ b/Regfiles/Undo/Enable_Explorer_Auto_Discovery.reg
@@ -1,0 +1,4 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_CURRENT_USER\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell]
+"FolderType"=-

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -48,6 +48,7 @@ param (
     [switch]$DisableSettings365Ads,
     [switch]$DisableSettingsHome,
     [switch]$ShowHiddenFolders,
+    [switch]$DisableExplorerAutoDiscovery,
     [switch]$ShowKnownFileExt,
     [switch]$HideDupliDrive,
     [switch]$EnableDarkMode,

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -47,6 +47,7 @@ param (
     [switch]$DisableSettings365Ads,
     [switch]$DisableSettingsHome,
     [switch]$ShowHiddenFolders,
+    [switch]$DisableExplorerAutoDiscovery,
     [switch]$ShowKnownFileExt,
     [switch]$HideDupliDrive,
     [switch]$EnableDarkMode,


### PR DESCRIPTION
## Summary
- Adds `-DisableExplorerAutoDiscovery` so File Explorer does not auto-detect folder types.
- Sets `FolderType="NotSpecified"` on `HKCU\Software\Classes\Local Settings\Software\Microsoft\Windows\Shell\Bags\AllFolders\Shell`.
- Relies on the existing Explorer restart after changes. Not added to the default preset.

Fixes #689

## Test plan
- [ ] Apply the option and confirm `FolderType` is `NotSpecified` on the AllFolders Shell bag
- [ ] Undo restores the previous value
- [ ] Sysprep `.reg` uses `hkey_users\default`
- [ ] Explorer restart still picks up the change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Added the `-DisableExplorerAutoDiscovery` switch.
- Set Explorer’s `FolderType` to `NotSpecified` under the current user’s `AllFolders\Shell` registry key.
- Added apply, undo, and Sysprep registry files.
- Documented the feature in `README.md`.
- Excluded the feature from the default preset.
- Explorer must restart before the setting takes effect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->