### PR TITLE
Add an option to disable hibernation with powercfg and remove hiberfil.sys

### DIFF
--- a/Config/Features.json
+++ b/Config/Features.json
@@ -1037,6 +1037,19 @@
       "MaxVersion": null
     },
     {
+      "FeatureId": "DisableHibernate",
+      "Label": "Disable hibernation and delete hiberfil.sys",
+      "ToolTip": "Turns hibernation off with powercfg /hibernate off. This also disables Fast Start-up, removes Hibernate from the power menu, and deletes hiberfil.sys so it no longer uses a large amount of disk space.",
+      "Category": "System",
+      "RegistryKey": null,
+      "ApplyText": "Disabling hibernation and removing hiberfil.sys",
+      "UndoLabel": "Enable hibernation",
+      "ApplyUndoText": "Enabling hibernation",
+      "RegistryUndoKey": null,
+      "MinVersion": null,
+      "MaxVersion": null
+    },
+    {
       "FeatureId": "DisableBitlockerAutoEncryption",
       "Label": "Disable BitLocker automatic device encryption",
       "ToolTip": "For devices that support it, Windows 11 automatically enables BitLocker device encryption. Disabling this will turn off automatic encryption of the device, but you can still manually enable BitLocker encryption if desired. Drives that are already encrypted with BitLocker will remain encrypted when this setting is applied.",

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Below is an overview of the key features and functionality offered by Win11Deblo
 - Disable the Sticky Keys keyboard shortcut.
 - Disable Storage Sense automatic disk cleanup.
 - Disable fast start-up to ensure a full shutdown.
+- Disable hibernation entirely (also removes hiberfil.sys).
 - Disable BitLocker automatic device encryption.
 - Disable network connectivity during Modern Standby to reduce battery drain.
 

--- a/Scripts/Features/Get-CurrentTweakState.ps1
+++ b/Scripts/Features/Get-CurrentTweakState.ps1
@@ -78,6 +78,9 @@ function Test-FeatureApplied {
             $vmpEnabled = Test-WindowsOptionalFeatureEnabled -FeatureName 'VirtualMachinePlatform'
             return ($wslEnabled -and $vmpEnabled)
         }
+        'DisableHibernate' {
+            return (Test-WindowsHibernateDisabled)
+        }
     }
 
     if (-not $feature.RegistryKey) { return $false }

--- a/Scripts/Features/Get-CurrentTweakState.ps1
+++ b/Scripts/Features/Get-CurrentTweakState.ps1
@@ -30,7 +30,7 @@ function Get-ExpectedRegistryValueKind {
         Returns $true when ALL operations in the apply .reg file match current system
         state. Returns $false if the feature has no RegistryKey, the reg file is
         missing, or any operation mismatches. Special-cased features (Widgets, Store
-        suggestions, Windows Sandbox, WSL) bypass .reg checking entirely.
+        suggestions, Windows Sandbox, WSL, hibernation) bypass .reg checking entirely.
 
     .PARAMETER FeatureId
         The feature identifier to test.

--- a/Scripts/Features/Invoke-Changes.ps1
+++ b/Scripts/Features/Invoke-Changes.ps1
@@ -139,6 +139,12 @@ function Invoke-FeatureApply {
             Write-Host ""
             return
         }
+        'DisableHibernate' {
+            Write-Host "> $applyText..."
+            Set-WindowsHibernate -Enabled $false
+            Write-Host ""
+            return
+        }
     }
 }
 
@@ -187,6 +193,12 @@ function Invoke-FeatureUndo {
             Write-Host "> $($feature.ApplyUndoText)..."
             Disable-WindowsFeature 'Microsoft-Windows-Subsystem-Linux'
             Disable-WindowsFeature 'VirtualMachinePlatform'
+            Write-Host ""
+            return
+        }
+        'DisableHibernate' {
+            Write-Host "> $($feature.ApplyUndoText)..."
+            Set-WindowsHibernate -Enabled $true
             Write-Host ""
             return
         }

--- a/Scripts/Features/Windows-OptionalFeatures.ps1
+++ b/Scripts/Features/Windows-OptionalFeatures.ps1
@@ -52,10 +52,44 @@ function Test-WindowsOptionalFeatureEnabled {
 
     try {
         $feature = Get-WindowsOptionalFeature -Online -FeatureName $FeatureName -ErrorAction Stop
+        return $feature.State -eq 'Enabled'
     }
     catch {
         return $false
     }
+}
 
-    return ($feature.State -eq 'Enabled')
+function Set-WindowsHibernate {
+    param(
+        [Parameter(Mandatory)]
+        [bool]$Enabled
+    )
+
+    $state = if ($Enabled) { 'on' } else { 'off' }
+
+    if ($script:Params.ContainsKey("WhatIf")) {
+        Write-Host "[WhatIf] powercfg /hibernate $state" -ForegroundColor Cyan
+        Write-Host ""
+        return
+    }
+
+    $null = Invoke-NonBlocking -ScriptBlock {
+        param($hibernateState)
+        $powerCfg = Join-Path $env:SystemRoot 'System32\powercfg.exe'
+        $process = Start-Process -FilePath $powerCfg -ArgumentList @('/hibernate', $hibernateState) -Wait -PassThru -WindowStyle Hidden
+        if ($null -eq $process -or $process.ExitCode -ne 0) {
+            $exitCode = if ($process) { $process.ExitCode } else { 'unknown' }
+            throw "powercfg /hibernate $hibernateState failed with exit code $exitCode"
+        }
+    } -ArgumentList $state
+}
+
+function Test-WindowsHibernateDisabled {
+    try {
+        $value = Get-ItemPropertyValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -ErrorAction Stop
+        return ([int]$value -eq 0)
+    }
+    catch {
+        return $false
+    }
 }

--- a/Scripts/Features/Windows-OptionalFeatures.ps1
+++ b/Scripts/Features/Windows-OptionalFeatures.ps1
@@ -44,6 +44,17 @@ function Disable-WindowsFeature {
     }
 }
 
+<#
+    .SYNOPSIS
+        Returns whether a Windows optional feature is currently enabled.
+
+    .DESCRIPTION
+        Queries Get-WindowsOptionalFeature for the given feature name. Returns
+        $false when the query fails or the feature is not enabled.
+
+    .PARAMETER FeatureName
+        The DISM optional-feature name to inspect.
+#>
 function Test-WindowsOptionalFeatureEnabled {
     param (
         [Parameter(Mandatory)]
@@ -59,6 +70,19 @@ function Test-WindowsOptionalFeatureEnabled {
     }
 }
 
+<#
+    .SYNOPSIS
+        Turns hibernation on or off with powercfg.exe.
+
+    .DESCRIPTION
+        Runs `powercfg /hibernate on` or `powercfg /hibernate off` through the
+        non-blocking runner. Turning hibernation off also disables Fast Start-up
+        and deletes hiberfil.sys. When -WhatIf is set, prints the planned command
+        and does not invoke powercfg.
+
+    .PARAMETER Enabled
+        $true enables hibernation; $false disables it.
+#>
 function Set-WindowsHibernate {
     param(
         [Parameter(Mandatory)]
@@ -84,6 +108,15 @@ function Set-WindowsHibernate {
     } -ArgumentList $state
 }
 
+<#
+    .SYNOPSIS
+        Returns whether hibernation is currently disabled.
+
+    .DESCRIPTION
+        Reads HKLM:\SYSTEM\CurrentControlSet\Control\Power\HibernateEnabled.
+        Returns $true when the value is 0, and $false when the value is missing
+        or any other value.
+#>
 function Test-WindowsHibernateDisabled {
     try {
         $value = Get-ItemPropertyValue -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Power' -Name 'HibernateEnabled' -ErrorAction Stop

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -28,6 +28,7 @@ param (
     [switch]$DisableTelemetry,
     [switch]$DisableSearchHistory,
     [switch]$DisableFastStartup,
+    [switch]$DisableHibernate,
     [switch]$DisableBitlockerAutoEncryption,
     [switch]$DisableModernStandbyNetworking,
     [switch]$DisableNotifications,

--- a/Tests/Get-CurrentTweakState.Tests.ps1
+++ b/Tests/Get-CurrentTweakState.Tests.ps1
@@ -4,6 +4,7 @@ BeforeAll {
     function Get-StoreAppsDatabasePathForUser { param($UserName) 'store.db' }
     function Get-UserName { 'Alice' }
     function Test-WindowsOptionalFeatureEnabled { param($FeatureName) $false }
+    function Test-WindowsHibernateDisabled { $false }
     function Get-RegFileOperations { param($regFilePath) @() }
     function Split-RegistryPath { param($path) $null }
     function Get-RegistryRootKey { param($hiveName) $null }
@@ -48,6 +49,7 @@ Describe 'Test-FeatureApplied - special features' {
             DisableStoreSearchSuggestions = [PSCustomObject]@{}
             EnableWindowsSandbox = [PSCustomObject]@{}
             EnableWindowsSubsystemForLinux = [PSCustomObject]@{}
+            DisableHibernate = [PSCustomObject]@{}
         }
         Mock Get-AppxPackage { $null }
         Mock Test-StoreSearchSuggestionsDisabledForAllUsers { $true }
@@ -55,6 +57,7 @@ Describe 'Test-FeatureApplied - special features' {
         Mock Get-StoreAppsDatabasePathForUser { 'store.db' }
         Mock Get-UserName { 'Alice' }
         Mock Test-WindowsOptionalFeatureEnabled { $true }
+        Mock Test-WindowsHibernateDisabled { $true }
     }
 
     It '<Case>' -ForEach @(
@@ -88,6 +91,11 @@ Describe 'Test-FeatureApplied - special features' {
     ) {
         Mock Test-WindowsOptionalFeatureEnabled { param($FeatureName) $FeatureName -ne $DisabledFeature }
         Test-FeatureApplied -FeatureId 'EnableWindowsSubsystemForLinux' | Should -Be $Expected
+    }
+
+    It 'treats hibernation as disabled when Test-WindowsHibernateDisabled returns true' {
+        Test-FeatureApplied -FeatureId 'DisableHibernate' | Should -BeTrue
+        Should -Invoke Test-WindowsHibernateDisabled -Times 1 -Exactly
     }
 }
 

--- a/Tests/Invoke-Changes.Tests.ps1
+++ b/Tests/Invoke-Changes.Tests.ps1
@@ -19,6 +19,7 @@ BeforeAll {
     function Replace-StartMenuForAllUsers { param($startMenuTemplate) }
     function Set-StoreSearchSuggestionsDisabledForAllUsers {}
     function Set-StoreSearchSuggestionsDisabled { param($StoreAppsDatabase) }
+    function Set-WindowsHibernate { param($Enabled) }
 
     . (Join-Path $PSScriptRoot '..\Scripts\Features\Invoke-Changes.ps1')
 }
@@ -61,6 +62,7 @@ Describe 'Invoke-FeatureApply' {
             ClearStartAllUsers = [PSCustomObject]@{ ApplyText = 'Clear Start all users'; RegistryKey = '' }
             ReplaceStartAllUsers = [PSCustomObject]@{ ApplyText = 'Replace Start all users'; RegistryKey = '' }
             DisableStoreSearchSuggestions = [PSCustomObject]@{ ApplyText = 'Disable Store suggestions'; RegistryKey = '' }
+            DisableHibernate = [PSCustomObject]@{ ApplyText = 'Disable hibernate'; RegistryKey = '' }
         }
         Mock Import-RegistryFile {}
         Mock Remove-SelectedApps {}
@@ -75,6 +77,7 @@ Describe 'Invoke-FeatureApply' {
         Mock Replace-StartMenuForAllUsers {}
         Mock Set-StoreSearchSuggestionsDisabledForAllUsers {}
         Mock Set-StoreSearchSuggestionsDisabled {}
+        Mock Set-WindowsHibernate {}
         Mock Get-StoreAppsDatabasePathForUser { 'store.db' }
         Mock Get-Process { @() }
         Mock Stop-Process { param($InputObject) }
@@ -166,6 +169,12 @@ Describe 'Invoke-FeatureApply' {
         Should -Invoke Enable-WindowsFeature -Times 1 -Exactly -ParameterFilter { $FeatureName -eq 'Containers-DisposableClientVM' }
         Should -Invoke Enable-WindowsFeature -Times 1 -Exactly -ParameterFilter { $FeatureName -eq 'VirtualMachinePlatform' }
         Should -Invoke Enable-WindowsFeature -Times 1 -Exactly -ParameterFilter { $FeatureName -eq 'Microsoft-Windows-Subsystem-Linux' }
+    }
+
+    It 'turns hibernation off through Set-WindowsHibernate' {
+        Invoke-FeatureApply -FeatureId 'DisableHibernate'
+
+        Should -Invoke Set-WindowsHibernate -Times 1 -Exactly -ParameterFilter { $Enabled -eq $false }
     }
 
     It 'applies current-user Start layouts only when a target path resolves' {
@@ -282,6 +291,7 @@ Describe 'Invoke-FeatureUndo' {
             EnableWindowsSubsystemForLinux = [PSCustomObject]@{ ApplyUndoText = 'Disable WSL' }
             DisableTelemetry = [PSCustomObject]@{}
             DisableStoreSearchSuggestions = [PSCustomObject]@{}
+            DisableHibernate = [PSCustomObject]@{ ApplyUndoText = 'Enable hibernation' }
         }
         Mock Set-StoreSearchSuggestionsEnabledForAllUsers {}
         Mock Set-StoreSearchSuggestionsEnabled {}
@@ -289,6 +299,7 @@ Describe 'Invoke-FeatureUndo' {
         Mock Get-UserName { 'Alice' }
         Mock Disable-WindowsFeature {}
         Mock Enable-TelemetryScheduledTasks {}
+        Mock Set-WindowsHibernate {}
         Mock Write-Host {}
     }
 
@@ -314,6 +325,12 @@ Describe 'Invoke-FeatureUndo' {
         Invoke-FeatureUndo -FeatureId 'DisableTelemetry'
         Should -Invoke Disable-WindowsFeature -Times 1 -Exactly -ParameterFilter { $FeatureName -eq 'Containers-DisposableClientVM' }
         Should -Invoke Enable-TelemetryScheduledTasks -Times 1 -Exactly
+    }
+
+    It 'turns hibernation back on through Set-WindowsHibernate' {
+        Invoke-FeatureUndo -FeatureId 'DisableHibernate'
+
+        Should -Invoke Set-WindowsHibernate -Times 1 -Exactly -ParameterFilter { $Enabled -eq $true }
     }
 }
 

--- a/Tests/TestSuiteSafety.Tests.ps1
+++ b/Tests/TestSuiteSafety.Tests.ps1
@@ -37,6 +37,8 @@ Describe 'Test suite safety convention' {
             'Unregister-ScheduledTask'
             'bcdedit'
             'bcdedit.exe'
+            'powercfg'
+            'powercfg.exe'
             'dism'
             'dism.exe'
             'fsutil'

--- a/Tests/Windows-OptionalFeatures.Tests.ps1
+++ b/Tests/Windows-OptionalFeatures.Tests.ps1
@@ -154,3 +154,51 @@ Describe 'Test-WindowsOptionalFeatureEnabled' {
         Test-WindowsOptionalFeatureEnabled -FeatureName 'Feature.One' | Should -BeFalse
     }
 }
+
+Describe 'Set-WindowsHibernate' {
+    BeforeEach {
+        $script:Params = @{}
+        Mock Invoke-NonBlocking { @() }
+        Mock Write-Host {}
+    }
+
+    It 'schedules powercfg hibernate off' {
+        Set-WindowsHibernate -Enabled $false
+
+        Should -Invoke Invoke-NonBlocking -Times 1 -Exactly -ParameterFilter { $ArgumentList -eq 'off' }
+    }
+
+    It 'schedules powercfg hibernate on' {
+        Set-WindowsHibernate -Enabled $true
+
+        Should -Invoke Invoke-NonBlocking -Times 1 -Exactly -ParameterFilter { $ArgumentList -eq 'on' }
+    }
+
+    It 'does not schedule changes in WhatIf mode' {
+        $script:Params = @{ WhatIf = $true }
+
+        Set-WindowsHibernate -Enabled $false
+
+        Should -Invoke Invoke-NonBlocking -Times 0 -Exactly
+    }
+}
+
+Describe 'Test-WindowsHibernateDisabled' {
+    It 'returns true when HibernateEnabled is 0' {
+        Mock Get-ItemPropertyValue { 0 }
+
+        Test-WindowsHibernateDisabled | Should -BeTrue
+    }
+
+    It 'returns false when HibernateEnabled is 1' {
+        Mock Get-ItemPropertyValue { 1 }
+
+        Test-WindowsHibernateDisabled | Should -BeFalse
+    }
+
+    It 'returns false when the registry value cannot be read' {
+        Mock Get-ItemPropertyValue { throw 'missing' }
+
+        Test-WindowsHibernateDisabled | Should -BeFalse
+    }
+}

--- a/Win11Debloat.ps1
+++ b/Win11Debloat.ps1
@@ -26,6 +26,7 @@ param (
     [switch]$DisableTelemetry,
     [switch]$DisableSearchHistory,
     [switch]$DisableFastStartup,
+    [switch]$DisableHibernate,
     [switch]$DisableBitlockerAutoEncryption,
     [switch]$DisableModernStandbyNetworking,
     [switch]$DisableStorageSense,


### PR DESCRIPTION
## Summary
- Adds `-DisableHibernate`, which runs `powercfg /hibernate off` to disable hibernation, Fast Start-up, and remove `hiberfil.sys`.
- Undo runs `powercfg /hibernate on`. Status is read from `HKLM\SYSTEM\CurrentControlSet\Control\Power\HibernateEnabled`.
- Uses the existing non-blocking runner; tests mock `powercfg` and do not mutate the host. Not added to the default preset.

Fixes #247

## Test plan
- [ ] Apply `-DisableHibernate` and confirm `powercfg /hibernate` reports off and `hiberfil.sys` is gone
- [ ] Undo re-enables hibernation
- [ ] WhatIf prints the planned `powercfg` command without running it
- [ ] `.\Scripts\Run-Tests.ps1` passes, including the new optional-feature and invoke-changes cases


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

# Summary by CodeRabbit

Adds the `-DisableHibernate` option.

- Runs `powercfg.exe /hibernate off` to disable hibernation, Fast Start-up, and `hiberfil.sys`.
- Uses `HKLM\SYSTEM\CurrentControlSet\Control\Power\HibernateEnabled` to detect the current state.
- Supports undo with `powercfg.exe /hibernate on`.
- Excludes the option from the default preset.
- Adds apply, undo, status, and safety tests with mocked `powercfg.exe` calls.
- Documents the option in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->