### PR TITLE
Keep restoring remaining registry snapshots when one key fails

### DIFF
--- a/Scripts/Features/Restore-RegistryBackup.ps1
+++ b/Scripts/Features/Restore-RegistryBackup.ps1
@@ -204,8 +204,23 @@ function Restore-RegistryBackupState {
         param($normalizedBackup)
 
         Write-Host "Applying registry restore from $(@($normalizedBackup.RegistryKeys).Count) root snapshot(s)."
+        $failedSnapshots = New-Object System.Collections.Generic.List[string]
         foreach ($rootSnapshot in @($normalizedBackup.RegistryKeys)) {
-            Restore-RegistryKeySnapshot -Snapshot $rootSnapshot
+            try {
+                Restore-RegistryKeySnapshot -Snapshot $rootSnapshot
+            }
+            catch {
+                $snapshotPath = [string]$rootSnapshot.Path
+                if ([string]::IsNullOrWhiteSpace($snapshotPath)) {
+                    $snapshotPath = '(unknown path)'
+                }
+                Write-Host "Failed to restore registry snapshot '$snapshotPath': $($_.Exception.Message)" -ForegroundColor Yellow
+                $failedSnapshots.Add($snapshotPath)
+            }
+        }
+
+        if ($failedSnapshots.Count -gt 0) {
+            throw "Restored remaining registry snapshots, but $($failedSnapshots.Count) failed: $($failedSnapshots -join '; ')"
         }
     }
 

--- a/Scripts/Features/Restore-RegistryBackup.ps1
+++ b/Scripts/Features/Restore-RegistryBackup.ps1
@@ -222,7 +222,7 @@ function Restore-RegistryBackupState {
         }
 
         if ($failedSnapshots.Count -gt 0) {
-            throw "Restored remaining registry snapshots, but $($failedSnapshots.Count) failed: $($failedSnapshots -join '; ')"
+            throw "Processed registry snapshots, but $($failedSnapshots.Count) failed: $($failedSnapshots -join '; ')"
         }
     }
 

--- a/Scripts/Features/Restore-RegistryBackup.ps1
+++ b/Scripts/Features/Restore-RegistryBackup.ps1
@@ -176,7 +176,9 @@ function ConvertTo-NormalizedRegistryBackup {
 
     .DESCRIPTION
         Applies the registry state described by the supplied backup back to the
-        registry, loading the appropriate user hive when required.
+        registry, loading the appropriate user hive when required. If a root
+        snapshot fails, restoration continues for the remaining snapshots and a
+        summary error is thrown after all snapshots have been processed.
 
     .PARAMETER Backup
         A normalized backup object (as produced by ConvertTo-NormalizedRegistryBackup) whose
@@ -184,8 +186,8 @@ function ConvertTo-NormalizedRegistryBackup {
 
     .OUTPUTS
         PSCustomObject
-        Returns an object with a Result property set to $true when the restore
-        completes successfully.
+        Returns an object with a Result property set to $true only when every
+        snapshot restores successfully.
 #>
 function Restore-RegistryBackupState {
     param(

--- a/Tests/Restore-RegistryBackup.Tests.ps1
+++ b/Tests/Restore-RegistryBackup.Tests.ps1
@@ -123,6 +123,20 @@ Describe 'Restore-RegistryBackupState' {
         Should -Invoke Invoke-WithLoadedRestoreHive -Times 0 -Exactly
     }
 
+    It 'continues restoring later snapshots when one root snapshot fails' {
+        Mock Restore-RegistryKeySnapshot {
+            param($Snapshot)
+            if ($Snapshot.Path -eq 'HKEY_CURRENT_USER\Software\One') {
+                throw 'access denied'
+            }
+        }
+
+        { Restore-RegistryBackupState -Backup $script:backup } |
+            Should -Throw "Restored remaining registry snapshots, but 1 failed: HKEY_CURRENT_USER\Software\One"
+
+        Should -Invoke Restore-RegistryKeySnapshot -Times 2 -Exactly
+    }
+
     It 'delegates default-profile restores through the loaded hive wrapper' {
         $script:backup.Target = 'DefaultUserProfile'
         Mock Invoke-WithLoadedRestoreHive {

--- a/Tests/Restore-RegistryBackup.Tests.ps1
+++ b/Tests/Restore-RegistryBackup.Tests.ps1
@@ -132,9 +132,12 @@ Describe 'Restore-RegistryBackupState' {
         }
 
         { Restore-RegistryBackupState -Backup $script:backup } |
-            Should -Throw "Restored remaining registry snapshots, but 1 failed: HKEY_CURRENT_USER\Software\One"
+            Should -Throw "Processed registry snapshots, but 1 failed: HKEY_CURRENT_USER\Software\One"
 
-        Should -Invoke Restore-RegistryKeySnapshot -Times 2 -Exactly
+        Should -Invoke Restore-RegistryKeySnapshot -Times 1 -Exactly `
+            -ParameterFilter { $Snapshot.Path -eq 'HKEY_CURRENT_USER\Software\One' }
+        Should -Invoke Restore-RegistryKeySnapshot -Times 1 -Exactly `
+            -ParameterFilter { $Snapshot.Path -eq 'HKEY_CURRENT_USER\Software\Two' }
     }
 
     It 'delegates default-profile restores through the loaded hive wrapper' {


### PR DESCRIPTION
## Summary
- Registry restore now isolates failures per root snapshot instead of aborting the whole backup on the first error.
- Remaining keys still restore; a summary exception is thrown afterward if any snapshot failed.

## Test plan
- [ ] Restoring two snapshots still applies both when both succeed
- [ ] If the first snapshot throws, the second still restores and the overall restore reports the failed path
- [ ] WhatIf still skips restore entirely


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Continue restoring registry snapshots when one snapshot fails.
- Record failed snapshot paths and throw an aggregate error after all snapshots are processed.
- Add test coverage for continued restoration and aggregate failure reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->