### PR TITLE
Add FeatureId and launcher parameter contract tests

### DIFF
--- a/Tests/FeatureParameterContracts.Tests.ps1
+++ b/Tests/FeatureParameterContracts.Tests.ps1
@@ -6,20 +6,20 @@ BeforeAll {
     $script:RegfilesPath = Join-Path $script:RepoRoot 'Regfiles'
     $script:Features = @((Get-Content -LiteralPath $script:FeaturesPath -Raw | ConvertFrom-Json).Features)
     $script:LauncherOnlyParameters = @('Dev', 'Verbose', 'WhatIf')
-}
 
-function Get-ScriptParameterNames {
-    param(
-        [Parameter(Mandatory)]
-        [string]$Path
-    )
+    function Get-ScriptParameterNames {
+        param(
+            [Parameter(Mandatory)]
+            [string]$Path
+        )
 
-    $tokens = $null
-    $parseErrors = $null
-    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
-    $parseErrors | Should -BeNullOrEmpty
+        $tokens = $null
+        $parseErrors = $null
+        $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
+        $parseErrors | Should -BeNullOrEmpty
 
-    @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath })
+        @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath })
+    }
 }
 
 Describe 'FeatureId parameter contracts' {
@@ -41,12 +41,17 @@ Describe 'FeatureId parameter contracts' {
         $win11DebloatParameters = Get-ScriptParameterNames -Path $script:Win11DebloatPath
         $getParameters = Get-ScriptParameterNames -Path $script:GetScriptPath
         $missingFromGet = @($win11DebloatParameters | Where-Object { $getParameters -notcontains $_ })
+        $missingLauncherOnly = @(
+            $script:LauncherOnlyParameters |
+                Where-Object { $getParameters -notcontains $_ }
+        )
         $unexpectedOnGet = @(
             $getParameters |
                 Where-Object { $win11DebloatParameters -notcontains $_ -and $script:LauncherOnlyParameters -notcontains $_ }
         )
 
         $missingFromGet | Should -HaveCount 0 -Because ($missingFromGet -join ', ')
+        $missingLauncherOnly | Should -HaveCount 0 -Because ($missingLauncherOnly -join ', ')
         $unexpectedOnGet | Should -HaveCount 0 -Because ($unexpectedOnGet -join ', ')
     }
 
@@ -57,10 +62,10 @@ Describe 'FeatureId parameter contracts' {
 
                 $applyPath = Join-Path $script:RegfilesPath $feature.RegistryKey
                 $sysprepPath = Join-Path (Join-Path $script:RegfilesPath 'Sysprep') $feature.RegistryKey
-                if (-not (Test-Path -LiteralPath $applyPath)) {
+                if (-not (Test-Path -LiteralPath $applyPath -PathType Leaf)) {
                     "$($feature.FeatureId) missing Regfiles\$($feature.RegistryKey)"
                 }
-                if (-not (Test-Path -LiteralPath $sysprepPath)) {
+                if (-not (Test-Path -LiteralPath $sysprepPath -PathType Leaf)) {
                     "$($feature.FeatureId) missing Regfiles\Sysprep\$($feature.RegistryKey)"
                 }
             }
@@ -76,7 +81,7 @@ Describe 'FeatureId parameter contracts' {
 
                 $undoPath = Join-Path (Join-Path $script:RegfilesPath 'Undo') $feature.RegistryUndoKey
                 $rootPath = Join-Path $script:RegfilesPath $feature.RegistryUndoKey
-                if (-not ((Test-Path -LiteralPath $undoPath) -or (Test-Path -LiteralPath $rootPath))) {
+                if (-not ((Test-Path -LiteralPath $undoPath -PathType Leaf) -or (Test-Path -LiteralPath $rootPath -PathType Leaf))) {
                     "$($feature.FeatureId) missing undo file $($feature.RegistryUndoKey)"
                 }
             }

--- a/Tests/FeatureParameterContracts.Tests.ps1
+++ b/Tests/FeatureParameterContracts.Tests.ps1
@@ -1,0 +1,87 @@
+BeforeAll {
+    $script:RepoRoot = Join-Path $PSScriptRoot '..'
+    $script:FeaturesPath = Join-Path $script:RepoRoot 'Config\Features.json'
+    $script:Win11DebloatPath = Join-Path $script:RepoRoot 'Win11Debloat.ps1'
+    $script:GetScriptPath = Join-Path $script:RepoRoot 'Scripts\Get.ps1'
+    $script:RegfilesPath = Join-Path $script:RepoRoot 'Regfiles'
+    $script:Features = @((Get-Content -LiteralPath $script:FeaturesPath -Raw | ConvertFrom-Json).Features)
+    $script:LauncherOnlyParameters = @('Dev', 'Verbose', 'WhatIf')
+}
+
+function Get-ScriptParameterNames {
+    param(
+        [Parameter(Mandatory)]
+        [string]$Path
+    )
+
+    $tokens = $null
+    $parseErrors = $null
+    $ast = [System.Management.Automation.Language.Parser]::ParseFile($Path, [ref]$tokens, [ref]$parseErrors)
+    $parseErrors | Should -BeNullOrEmpty
+
+    @($ast.ParamBlock.Parameters | ForEach-Object { $_.Name.VariablePath.UserPath })
+}
+
+Describe 'FeatureId parameter contracts' {
+    It 'declares every FeatureId as a parameter on Win11Debloat.ps1' {
+        $parameterNames = Get-ScriptParameterNames -Path $script:Win11DebloatPath
+        $missing = @($script:Features.FeatureId | Where-Object { $parameterNames -notcontains $_ })
+
+        $missing | Should -HaveCount 0 -Because ($missing -join ', ')
+    }
+
+    It 'declares every FeatureId as a parameter on Scripts/Get.ps1' {
+        $parameterNames = Get-ScriptParameterNames -Path $script:GetScriptPath
+        $missing = @($script:Features.FeatureId | Where-Object { $parameterNames -notcontains $_ })
+
+        $missing | Should -HaveCount 0 -Because ($missing -join ', ')
+    }
+
+    It 'keeps Scripts/Get.ps1 aligned with Win11Debloat.ps1 plus launcher-only switches' {
+        $win11DebloatParameters = Get-ScriptParameterNames -Path $script:Win11DebloatPath
+        $getParameters = Get-ScriptParameterNames -Path $script:GetScriptPath
+        $missingFromGet = @($win11DebloatParameters | Where-Object { $getParameters -notcontains $_ })
+        $unexpectedOnGet = @(
+            $getParameters |
+                Where-Object { $win11DebloatParameters -notcontains $_ -and $script:LauncherOnlyParameters -notcontains $_ }
+        )
+
+        $missingFromGet | Should -HaveCount 0 -Because ($missingFromGet -join ', ')
+        $unexpectedOnGet | Should -HaveCount 0 -Because ($unexpectedOnGet -join ', ')
+    }
+
+    It 'keeps every RegistryKey file in Regfiles and Regfiles/Sysprep' {
+        $missing = @(
+            foreach ($feature in $script:Features) {
+                if ([string]::IsNullOrWhiteSpace($feature.RegistryKey)) { continue }
+
+                $applyPath = Join-Path $script:RegfilesPath $feature.RegistryKey
+                $sysprepPath = Join-Path (Join-Path $script:RegfilesPath 'Sysprep') $feature.RegistryKey
+                if (-not (Test-Path -LiteralPath $applyPath)) {
+                    "$($feature.FeatureId) missing Regfiles\$($feature.RegistryKey)"
+                }
+                if (-not (Test-Path -LiteralPath $sysprepPath)) {
+                    "$($feature.FeatureId) missing Regfiles\Sysprep\$($feature.RegistryKey)"
+                }
+            }
+        )
+
+        $missing | Should -HaveCount 0 -Because ($missing -join '; ')
+    }
+
+    It 'keeps every RegistryUndoKey file in Regfiles/Undo or Regfiles' {
+        $missing = @(
+            foreach ($feature in $script:Features) {
+                if ([string]::IsNullOrWhiteSpace($feature.RegistryUndoKey)) { continue }
+
+                $undoPath = Join-Path (Join-Path $script:RegfilesPath 'Undo') $feature.RegistryUndoKey
+                $rootPath = Join-Path $script:RegfilesPath $feature.RegistryUndoKey
+                if (-not ((Test-Path -LiteralPath $undoPath) -or (Test-Path -LiteralPath $rootPath))) {
+                    "$($feature.FeatureId) missing undo file $($feature.RegistryUndoKey)"
+                }
+            }
+        )
+
+        $missing | Should -HaveCount 0 -Because ($missing -join '; ')
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a Pester contract so every `Features.json` `FeatureId` is declared on both `Win11Debloat.ps1` and `Scripts/Get.ps1`.
- Also requires `Get.ps1` to stay aligned with the main script, plus the launcher-only `Dev`, `Verbose`, and `WhatIf` switches.
- Checks that `RegistryKey` files exist in `Regfiles/` and `Regfiles/Sysprep/`, and that `RegistryUndoKey` files exist in `Regfiles/Undo/` or `Regfiles/` (the existing grouped-feature fallback).

This encodes the CONTRIBUTING pitfalls around forgotten `Get.ps1` parameters and missing registry files. The tests only parse scripts and inspect files; they do not run the launcher.

## Test plan
- [ ] `Tests/FeatureParameterContracts.Tests.ps1` passes on this branch
- [ ] Removing a FeatureId parameter from `Get.ps1` fails the suite
- [ ] A missing Sysprep `.reg` for a `RegistryKey` feature fails the suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Added Pester contract tests for `FeatureId` declarations in `Win11Debloat.ps1` and `Scripts/Get.ps1`.
- Verified parameter alignment and launcher-only switches: `Dev`, `Verbose`, and `WhatIf`.
- Verified required registry files for `RegistryKey` and `RegistryUndoKey` entries, including grouped-feature fallback behavior.
- Parsed scripts with the PowerShell AST without running the launcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->