### PR TITLE
Run PSScriptAnalyzer at Error severity in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,9 +39,12 @@ jobs:
         shell: powershell
         run: |
           $ErrorActionPreference = 'Stop'
-          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
-            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -SkipPublisherCheck
+          $analyzerVersion = '1.25.0'
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer | Where-Object Version -eq $analyzerVersion)) {
+            Install-Module -Name PSScriptAnalyzer -RequiredVersion $analyzerVersion -Force -Scope CurrentUser -SkipPublisherCheck
           }
+          Import-Module -Name PSScriptAnalyzer -RequiredVersion $analyzerVersion -Force
+          . ./Scripts/CI/GitHub-WorkflowCommands.ps1
 
           $results = @(
             Invoke-ScriptAnalyzer -Path 'Win11Debloat.ps1' -Severity Error
@@ -57,7 +60,10 @@ jobs:
               if ($relative.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
                 $relative = $relative.Substring($repoRoot.Length).TrimStart('\')
               }
-              Write-Output ("::error file={0},line={1},col={2}::{3}: {4}" -f $relative, $result.Line, $result.Column, $result.RuleName, $result.Message)
+              $escapedFile = ConvertTo-GitHubWorkflowCommandProperty $relative
+              $escapedRule = ConvertTo-GitHubWorkflowCommandData ([string]$result.RuleName)
+              $escapedMessage = ConvertTo-GitHubWorkflowCommandData ([string]$result.Message)
+              Write-Output ("::error file={0},line={1},col={2}::{3}: {4}" -f $escapedFile, $result.Line, $result.Column, $escapedRule, $escapedMessage)
             }
             throw "PSScriptAnalyzer reported $($results.Count) error-severity issue(s)."
           }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,3 +24,42 @@ jobs:
       - name: Run tests
         shell: powershell
         run: ./Scripts/Run-Tests.ps1 -Bootstrap
+
+  psscriptanalyzer:
+    name: PSScriptAnalyzer (Error)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run PSScriptAnalyzer
+        shell: powershell
+        run: |
+          $ErrorActionPreference = 'Stop'
+          if (-not (Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
+            Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser -SkipPublisherCheck
+          }
+
+          $results = @(
+            Invoke-ScriptAnalyzer -Path 'Win11Debloat.ps1' -Severity Error
+            Invoke-ScriptAnalyzer -Path 'Scripts' -Recurse -Severity Error
+            Invoke-ScriptAnalyzer -Path 'Tests' -Recurse -Severity Error
+          )
+
+          if ($results.Count -gt 0) {
+            $results | Format-Table -AutoSize Severity, RuleName, ScriptName, Line, Message
+            $repoRoot = (Get-Location).Path.TrimEnd('\')
+            foreach ($result in $results) {
+              $relative = [string]$result.ScriptPath
+              if ($relative.StartsWith($repoRoot, [System.StringComparison]::OrdinalIgnoreCase)) {
+                $relative = $relative.Substring($repoRoot.Length).TrimStart('\')
+              }
+              Write-Output ("::error file={0},line={1},col={2}::{3}: {4}" -f $relative, $result.Line, $result.Column, $result.RuleName, $result.Message)
+            }
+            throw "PSScriptAnalyzer reported $($results.Count) error-severity issue(s)."
+          }
+
+          Write-Output 'PSScriptAnalyzer found no error-severity issues.'

--- a/Scripts/CI/GitHub-WorkflowCommands.ps1
+++ b/Scripts/CI/GitHub-WorkflowCommands.ps1
@@ -1,3 +1,14 @@
+<#
+.SYNOPSIS
+Escapes the data portion of a GitHub Actions workflow command.
+
+.DESCRIPTION
+Escapes percent signs, carriage returns and line feeds. Colons and commas are
+left unchanged because they are not delimiters in workflow-command data.
+
+.PARAMETER Value
+The workflow-command data value to escape.
+#>
 function ConvertTo-GitHubWorkflowCommandData {
     param(
         [AllowEmptyString()]
@@ -7,6 +18,17 @@ function ConvertTo-GitHubWorkflowCommandData {
     $Value.Replace('%', '%25').Replace("`r", '%0D').Replace("`n", '%0A')
 }
 
+<#
+.SYNOPSIS
+Escapes a property value in a GitHub Actions workflow command.
+
+.DESCRIPTION
+Applies workflow-command data escaping, then additionally escapes colons and
+commas because they delimit command properties.
+
+.PARAMETER Value
+The workflow-command property value to escape.
+#>
 function ConvertTo-GitHubWorkflowCommandProperty {
     param(
         [AllowEmptyString()]

--- a/Scripts/CI/GitHub-WorkflowCommands.ps1
+++ b/Scripts/CI/GitHub-WorkflowCommands.ps1
@@ -1,0 +1,17 @@
+function ConvertTo-GitHubWorkflowCommandData {
+    param(
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    $Value.Replace('%', '%25').Replace("`r", '%0D').Replace("`n", '%0A')
+}
+
+function ConvertTo-GitHubWorkflowCommandProperty {
+    param(
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    (ConvertTo-GitHubWorkflowCommandData $Value).Replace(':', '%3A').Replace(',', '%2C')
+}

--- a/Tests/GitHub-WorkflowCommands.Tests.ps1
+++ b/Tests/GitHub-WorkflowCommands.Tests.ps1
@@ -1,0 +1,15 @@
+BeforeAll {
+    . (Join-Path $PSScriptRoot '..\Scripts\CI\GitHub-WorkflowCommands.ps1')
+}
+
+Describe 'GitHub workflow command escaping' {
+    It 'escapes property delimiters and control characters' {
+        ConvertTo-GitHubWorkflowCommandProperty "Scripts\one,two:three%`r`n.ps1" |
+            Should -Be 'Scripts\one%2Ctwo%3Athree%25%0D%0A.ps1'
+    }
+
+    It 'escapes data control characters without changing commas or colons' {
+        ConvertTo-GitHubWorkflowCommandData "Rule%Name: bad, value`r`nnext" |
+            Should -Be 'Rule%25Name: bad, value%0D%0Anext'
+    }
+}


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions job that runs PSScriptAnalyzer at **Error** severity on `Win11Debloat.ps1`, `Scripts/`, and `Tests/`.
- Warnings and information findings do not fail the job. PowerShell 7 is not added to CI; Win11Debloat still requires Windows PowerShell 5.1.

## Test plan
- [ ] The new job is green on this PR
- [ ] Introducing an Error-severity analyzer issue fails the job and emits a GitHub annotation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
# Summary by CodeRabbit

- Added a Windows CI job that runs PSScriptAnalyzer 1.25.0 at Error severity against `Win11Debloat.ps1`, `Scripts/`, and `Tests/`.
- Configured the job to fail on Error-severity findings.
- Added escaped GitHub Actions annotations for analyzer errors.
- Documented and tested GitHub workflow command escaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->