### PR TITLE
fix: improve error reporting when fetching files from GitHub

### DIFF
--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -135,7 +135,7 @@ try {
 }
 catch {
     Write-Host "Unable to fetch required files from GitHub. Please check your internet connection and try again." -ForegroundColor Red
-    Write-Error "$_"
+    Write-Error -ErrorRecord $_
     Write-Output ""
     Write-Output "Press enter to exit..."
     Read-Host | Out-Null

--- a/Scripts/Get.ps1
+++ b/Scripts/Get.ps1
@@ -134,7 +134,8 @@ try {
     Invoke-RestMethod $sourceUri -OutFile $tempArchivePath
 }
 catch {
-    Write-Host "Error: Unable to fetch required files from GitHub. Please check your internet connection and try again." -ForegroundColor Red
+    Write-Host "Unable to fetch required files from GitHub. Please check your internet connection and try again." -ForegroundColor Red
+    Write-Error "$_"
     Write-Output ""
     Write-Output "Press enter to exit..."
     Read-Host | Out-Null


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improved GitHub file download error reporting in `Scripts/Get.ps1`.
- Removed the literal `Error:` prefix from the download failure message.
- Added separate error output through `Write-Error -ErrorRecord`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->